### PR TITLE
Fix mobile mode labels overlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+.pnpm-store/
 
 # Build outputs
 dist/

--- a/packages/client/src/components/ModeSelector.tsx
+++ b/packages/client/src/components/ModeSelector.tsx
@@ -17,6 +17,13 @@ const MODE_LABELS: Record<PermissionMode, string> = {
   bypassPermissions: "Bypass permissions",
 };
 
+const MODE_SHORT_LABELS: Record<PermissionMode, string> = {
+  default: "Ask",
+  acceptEdits: "Edit",
+  plan: "Plan",
+  bypassPermissions: "Bypass",
+};
+
 // Breakpoint for desktop behavior (should match CSS)
 const DESKTOP_BREAKPOINT = 769;
 
@@ -147,7 +154,9 @@ export function ModeSelector({
   };
 
   // Display text: show "Hold" when held, otherwise show mode label
-  const displayLabel = isHeld ? t("modeHold" as never) : MODE_LABELS[mode];
+  const desktopLabel = isHeld ? t("modeHold" as never) : MODE_LABELS[mode];
+  const mobileLabel = isHeld ? t("modeHold" as never) : MODE_SHORT_LABELS[mode];
+  const displayLabel = isDesktop ? desktopLabel : mobileLabel;
   const displayDotClass = isHeld ? "mode-hold" : `mode-${mode}`;
 
   // Shared options content used by both mobile sheet and desktop dropdown


### PR DESCRIPTION
## Summary
- add .pnpm-store/ to .gitignore
- use short mode labels on mobile mode selector (Ask/Edit/Plan/Bypass) while keeping full labels in the mode popup
-- before --
<img width="406" height="147" alt="image" src="https://github.com/user-attachments/assets/a726ace0-76b5-40ae-a30f-9ced30d03af0" />

-- after --
<img width="409" height="151" alt="image" src="https://github.com/user-attachments/assets/4085e282-8080-4ed9-bd5c-c80e3ee5696c" />
