### PR TITLE
Fix project session count merging and stale issue link

### DIFF
--- a/packages/client/src/components/ErrorBoundary.tsx
+++ b/packages/client/src/components/ErrorBoundary.tsx
@@ -125,7 +125,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 Reload Page
               </button>
               <a
-                href="https://github.com/anthropics/yep-anywhere/issues"
+                href="https://github.com/kzahel/yepanywhere/issues"
                 target="_blank"
                 rel="noopener noreferrer"
                 style={styles.issueLink}

--- a/packages/server/src/projects/scanner.ts
+++ b/packages/server/src/projects/scanner.ts
@@ -222,9 +222,6 @@ export class ProjectScanner {
       // (e.g. "C:\Users\sox/Documents/webvam" vs "C:\Users\sox\Documents\webvam")
       // are recognized as the same path.
       const projectPath = rawProjectPath.replace(/\\/g, "/");
-      if (seenPaths.has(projectPath)) return; // exact path duplicate
-      seenPaths.add(projectPath);
-
       const normalized = normalizeProjectPathForDedup(projectPath);
       const existingIdx = normalizedIndex.get(normalized);
 
@@ -232,6 +229,15 @@ export class ProjectScanner {
         // Cross-machine duplicate — merge into existing project
         const existing = projects[existingIdx];
         if (!existing) return;
+        const existingSessionDirs = new Set([
+          existing.sessionDir,
+          ...(existing.mergedSessionDirs ?? []),
+        ]);
+        if (existingSessionDirs.has(sessionDir)) {
+          return;
+        }
+
+        seenPaths.add(projectPath);
         existing.sessionCount += sessionCount;
         if (!existing.mergedSessionDirs) {
           existing.mergedSessionDirs = [];
@@ -263,6 +269,8 @@ export class ProjectScanner {
           existing.name = basename(projectPath);
         }
       } else {
+        if (seenPaths.has(projectPath)) return; // exact path duplicate
+        seenPaths.add(projectPath);
         normalizedIndex.set(normalized, projects.length);
         projects.push({
           id: encodeProjectId(projectPath),

--- a/packages/server/test/projects/scanner.test.ts
+++ b/packages/server/test/projects/scanner.test.ts
@@ -195,3 +195,50 @@ describe("ProjectScanner cache", () => {
     expect(afterEvent?.id).toBe(encodeProjectId("/home/user/project-two"));
   });
 });
+
+describe("ProjectScanner cross-host merging", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("merges session counts for the same project path across host directories", async () => {
+    const projectsDir = join(tmpdir(), `project-scanner-${randomUUID()}`);
+    tempDirs.push(projectsDir);
+
+    await createClaudeProject(
+      projectsDir,
+      "host-a",
+      "/home/user/shared-project",
+      "sess-1",
+    );
+    await createClaudeProject(
+      projectsDir,
+      "host-b",
+      "/home/user/shared-project",
+      "sess-2",
+    );
+
+    const scanner = new ProjectScanner({
+      projectsDir,
+      enableCodex: false,
+      enableGemini: false,
+    });
+
+    const projects = await scanner.listProjects();
+    const project = projects.find((p) => p.path === "/home/user/shared-project");
+
+    expect(projects).toHaveLength(1);
+    expect(project).toBeDefined();
+    expect(project?.sessionCount).toBe(2);
+    expect(project?.sessionDir).toContain("host-a");
+    expect(project?.mergedSessionDirs).toContain(
+      join(projectsDir, "host-b", encodePath("/home/user/shared-project")),
+    );
+  });
+});

--- a/packages/server/test/projects/scanner.test.ts
+++ b/packages/server/test/projects/scanner.test.ts
@@ -231,7 +231,9 @@ describe("ProjectScanner cross-host merging", () => {
     });
 
     const projects = await scanner.listProjects();
-    const project = projects.find((p) => p.path === "/home/user/shared-project");
+    const project = projects.find(
+      (p) => p.path === "/home/user/shared-project",
+    );
 
     expect(projects).toHaveLength(1);
     expect(project).toBeDefined();


### PR DESCRIPTION
## Summary

Fix two unrelated but small issues:

- fix project session counts when the same Claude project appears under multiple host directories
- fix a stale GitHub issue link in the client error boundary

## What changed

- update `ProjectScanner` merge logic so cross-host duplicates are merged before exact-path dedup short-circuits
- avoid double-counting when the same `sessionDir` is encountered more than once
- add a regression test covering one project path split across two host directories
- update `ErrorBoundary` to point to the current repo issues page

## Why

Project cards could undercount sessions for the same project when sessions were spread across multiple host folders under `~/.claude/projects/`. The merge path was skipped too early.

The error UI also still linked to an old `anthropics/yep-anywhere` issues URL.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @yep-anywhere/server test -- test/projects/scanner.test.ts`
- `pnpm --filter @yep-anywhere/server test -- test/session-filtering.test.ts`
- `pnpm --filter @yep-anywhere/server test -- test/api/projects.test.ts`
