### PR TITLE
Add project context to new session creation

### DIFF
--- a/packages/client/src/components/NewSessionForm.tsx
+++ b/packages/client/src/components/NewSessionForm.tsx
@@ -34,7 +34,7 @@ import { useRemoteExecutors } from "../hooks/useRemoteExecutors";
 import { useServerSettings } from "../hooks/useServerSettings";
 import { useI18n } from "../i18n";
 import { hasCoarsePointer } from "../lib/deviceDetection";
-import type { PermissionMode } from "../types";
+import type { PermissionMode, Project } from "../types";
 import { FilterDropdown, type FilterOption } from "./FilterDropdown";
 import { clearFabPrefill, getFabPrefill } from "./FloatingActionButton";
 import { VoiceInputButton, type VoiceInputButtonRef } from "./VoiceInputButton";
@@ -90,6 +90,10 @@ export interface NewSessionFormProps {
   placeholder?: string;
   /** Compact mode: no header, no mode selector (default: false) */
   compact?: boolean;
+  /** Available projects for inline project switching */
+  projects?: Project[];
+  /** Called when the user selects a different project */
+  onProjectChange?: (projectId: string) => void;
 }
 
 export function NewSessionForm({
@@ -98,6 +102,8 @@ export function NewSessionForm({
   rows = 6,
   placeholder,
   compact = false,
+  projects,
+  onProjectChange,
 }: NewSessionFormProps) {
   const { t } = useI18n();
   const navigate = useNavigate();
@@ -779,6 +785,29 @@ export function NewSessionForm({
       </div>
 
       <div className="new-session-input-area">{inputArea}</div>
+
+      {/* Project Selection */}
+      {projects && projects.length > 1 && onProjectChange && (
+        <div className="new-session-project-section">
+          <h3>{t("newSessionProjectTitle")}</h3>
+          <FilterDropdown
+            label={t("newSessionProjectTitle")}
+            options={projects.map((p) => ({
+              value: p.id,
+              label: p.name,
+            }))}
+            selected={[projectId]}
+            onChange={(values) => {
+              const selected = values[0];
+              if (selected && selected !== projectId) {
+                onProjectChange(selected);
+              }
+            }}
+            multiSelect={false}
+            placeholder={t("newSessionProjectPlaceholder")}
+          />
+        </div>
+      )}
 
       {/* Provider Selection */}
       {!providersLoading && availableProviders.length > 1 && (

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { GlobalSessionItem } from "../api/client";
 import { useOptionalRemoteConnection } from "../contexts/RemoteConnectionContext";
 import { useDrafts } from "../hooks/useDrafts";
@@ -67,6 +67,7 @@ export function Sidebar({
   // Get base path for relay mode (e.g., "/remote/my-server")
   const basePath = useRemoteBasePath();
   const navigate = useNavigate();
+  const location = useLocation();
   const remoteConnection = useOptionalRemoteConnection();
 
   // Fetch global sessions for sidebar (non-starred only for recent/older sections)
@@ -90,10 +91,10 @@ export function Sidebar({
   // Global inbox count
   const inboxCount = useNeedsAttentionBadge();
   const { recentProjects, projects } = useRecentProjects();
-  const newSessionProjectId = resolvePreferredProjectId(
-    projects,
-    recentProjects[0]?.id,
-  );
+  // Prefer the project from the current URL (e.g., viewing a session), then fall back to recent
+  const currentUrlProjectId = extractProjectIdFromPath(location.pathname);
+  const newSessionProjectId =
+    currentUrlProjectId ?? resolvePreferredProjectId(projects, recentProjects[0]?.id);
 
   const sidebarRef = useRef<HTMLElement>(null);
   const touchStartX = useRef<number | null>(null);
@@ -619,4 +620,14 @@ export function Sidebar({
       </aside>
     </>
   );
+}
+
+/**
+ * Extract projectId from URL path.
+ * Matches: /projects/:projectId, /projects/:projectId/sessions/:sessionId,
+ * and relay mode paths like /remote/:username/projects/:projectId
+ */
+function extractProjectIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/\/projects\/([^/]+)/);
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
 }

--- a/packages/client/src/i18n/de.json
+++ b/packages/client/src/i18n/de.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "Wird gespeichert...",
   "newSessionDefaultsSaved": "Standardeinstellungen gespeichert",
   "newSessionDefaultsSaveError": "Standardeinstellungen konnten nicht gespeichert werden",
+  "newSessionProjectTitle": "Projekt",
+  "newSessionProjectPlaceholder": "Projekt auswählen",
   "newSessionProviderTitle": "KI-Anbieter",
   "newSessionProviderUnavailable": "{provider} ist nicht verfügbar ({reason})",
   "newSessionProviderNotInstalled": "nicht installiert",

--- a/packages/client/src/i18n/en.json
+++ b/packages/client/src/i18n/en.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "Saving...",
   "newSessionDefaultsSaved": "Saved new session defaults",
   "newSessionDefaultsSaveError": "Failed to save new session defaults",
+  "newSessionProjectTitle": "Project",
+  "newSessionProjectPlaceholder": "Select project",
   "newSessionProviderTitle": "AI Provider",
   "newSessionProviderUnavailable": "{provider} is not available ({reason})",
   "newSessionProviderNotInstalled": "not installed",

--- a/packages/client/src/i18n/es.json
+++ b/packages/client/src/i18n/es.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "Guardando...",
   "newSessionDefaultsSaved": "Valores predeterminados guardados",
   "newSessionDefaultsSaveError": "No se pudieron guardar los valores predeterminados",
+  "newSessionProjectTitle": "Proyecto",
+  "newSessionProjectPlaceholder": "Seleccionar proyecto",
   "newSessionProviderTitle": "Proveedor de IA",
   "newSessionProviderUnavailable": "{provider} no está disponible ({reason})",
   "newSessionProviderNotInstalled": "no instalado",

--- a/packages/client/src/i18n/fr.json
+++ b/packages/client/src/i18n/fr.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "Enregistrement...",
   "newSessionDefaultsSaved": "Valeurs par défaut enregistrées",
   "newSessionDefaultsSaveError": "Échec de l'enregistrement des valeurs par défaut",
+  "newSessionProjectTitle": "Projet",
+  "newSessionProjectPlaceholder": "Sélectionner un projet",
   "newSessionProviderTitle": "Fournisseur d'IA",
   "newSessionProviderUnavailable": "{provider} n'est pas disponible ({reason})",
   "newSessionProviderNotInstalled": "non installé",

--- a/packages/client/src/i18n/ja.json
+++ b/packages/client/src/i18n/ja.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "保存中...",
   "newSessionDefaultsSaved": "新しいセッションのデフォルトを保存しました",
   "newSessionDefaultsSaveError": "新しいセッションのデフォルトを保存できませんでした",
+  "newSessionProjectTitle": "プロジェクト",
+  "newSessionProjectPlaceholder": "プロジェクトを選択",
   "newSessionProviderTitle": "AI プロバイダー",
   "newSessionProviderUnavailable": "{provider} は利用できません（{reason}）",
   "newSessionProviderNotInstalled": "未インストール",

--- a/packages/client/src/i18n/zh-CN.json
+++ b/packages/client/src/i18n/zh-CN.json
@@ -153,6 +153,8 @@
   "newSessionDefaultsSaving": "正在保存...",
   "newSessionDefaultsSaved": "已保存新会话默认值",
   "newSessionDefaultsSaveError": "保存新会话默认值失败",
+  "newSessionProjectTitle": "项目",
+  "newSessionProjectPlaceholder": "选择项目",
   "newSessionProviderTitle": "AI 提供商",
   "newSessionProviderUnavailable": "{provider} 当前不可用（{reason}）",
   "newSessionProviderNotInstalled": "未安装",

--- a/packages/client/src/pages/NewSessionPage.tsx
+++ b/packages/client/src/pages/NewSessionPage.tsx
@@ -111,7 +111,11 @@ export function NewSessionPage() {
         <main className="page-scroll-container">
           <div className="page-content-inner">
             {effectiveProjectId && (
-              <NewSessionForm projectId={effectiveProjectId} />
+              <NewSessionForm
+                projectId={effectiveProjectId}
+                projects={projects}
+                onProjectChange={handleProjectChange}
+              />
             )}
           </div>
         </main>

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -4648,6 +4648,20 @@ a.sidebar-nav-item {
   color: var(--error-color);
 }
 
+/* Project Selection Section */
+.new-session-project-section {
+  margin-bottom: 1.5rem;
+}
+
+.new-session-project-section h3 {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 var(--space-3);
+}
+
 /* Provider Selection Section */
 .new-session-provider-section {
   margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary
- **Sidebar "New Session" button** now uses the project from the current URL (e.g., when viewing a session) instead of just the most recently used project, so clicking "New Session" while viewing a project creates the session in that project
- **Inline project dropdown** added to the new session form, allowing users to switch projects directly without navigating away. Uses the existing `FilterDropdown` component for consistent UX on desktop and mobile. Only shows when multiple projects exist.
- i18n translations added for all 6 locales (en, de, es, fr, ja, zh-CN)

## Test plan
- [ ] Navigate to a project's session list, click "New Session" in sidebar — verify it pre-selects that project
- [ ] On the new session page, verify the project dropdown appears below the input area (only when >1 project exists)
- [ ] Change project via the dropdown — verify the URL updates and the form context switches
- [ ] Verify the header ProjectSelector and inline dropdown stay in sync
- [ ] Test on mobile — verify FilterDropdown renders as bottom sheet for project selection