### PR TITLE
Send push notifications when sessions halt

### DIFF
--- a/packages/server/src/push/PushNotifier.ts
+++ b/packages/server/src/push/PushNotifier.ts
@@ -3,8 +3,9 @@
  *
  * Listens to EventBus for process state changes and sends push notifications
  * when a session enters waiting-input state (tool approval or user question).
- * The service worker on the client handles suppressing notifications when
- * the app is already focused.
+ * It also sends session-halted notifications when a live process reaches idle
+ * or terminates unexpectedly. The service worker on the client handles
+ * suppressing notifications when the app is already focused.
  */
 
 import { basename } from "node:path";
@@ -17,9 +18,14 @@ import type {
   BusEvent,
   EventBus,
   ProcessStateEvent,
+  ProcessTerminatedEvent,
 } from "../watcher/EventBus.js";
 import type { PushService } from "./PushService.js";
-import type { DismissPayload, PendingInputPayload } from "./types.js";
+import type {
+  DismissPayload,
+  PendingInputPayload,
+  SessionHaltedPayload,
+} from "./types.js";
 
 export interface PushNotifierOptions {
   eventBus: EventBus;
@@ -48,6 +54,10 @@ export class PushNotifier {
     this.unsubscribe = this.eventBus.subscribe((event: BusEvent) => {
       if (event.type === "process-state-changed") {
         void this.handleProcessStateChange(event);
+        return;
+      }
+      if (event.type === "process-terminated") {
+        void this.handleProcessTerminated(event);
       }
     });
   }
@@ -65,6 +75,13 @@ export class PushNotifier {
       if (this.sessionsWithNotification.has(event.sessionId)) {
         await this.sendDismiss(event.sessionId);
         this.sessionsWithNotification.delete(event.sessionId);
+      }
+      if (event.activity === "idle") {
+        await this.sendSessionHalted(
+          event.sessionId,
+          event.projectId,
+          "completed",
+        );
       }
       return;
     }
@@ -131,6 +148,17 @@ export class PushNotifier {
     }
   }
 
+  private async handleProcessTerminated(
+    event: ProcessTerminatedEvent,
+  ): Promise<void> {
+    if (this.sessionsWithNotification.has(event.sessionId)) {
+      await this.sendDismiss(event.sessionId);
+      this.sessionsWithNotification.delete(event.sessionId);
+    }
+
+    await this.sendSessionHalted(event.sessionId, event.projectId, "error");
+  }
+
   /**
    * Send a dismiss notification to close notifications on all devices.
    */
@@ -150,6 +178,63 @@ export class PushNotifier {
       console.log(`[PushNotifier] Sent dismiss for session ${sessionId}`);
     } catch (error) {
       console.error("[PushNotifier] Failed to send dismiss:", error);
+    }
+  }
+
+  private async sendSessionHalted(
+    sessionId: string,
+    projectId: UrlProjectId,
+    reason: SessionHaltedPayload["reason"],
+  ): Promise<void> {
+    if (this.pushService.getSubscriptionCount() === 0) {
+      return;
+    }
+    if (!this.pushService.isNotificationTypeEnabled("sessionHalted")) {
+      return;
+    }
+
+    const process = this.supervisor.getProcessForSession(sessionId);
+    if (reason === "completed" && (!process || process.state.type !== "idle")) {
+      // Ignore the synthetic idle emitted during unregister. We only want the
+      // live transition while the process is still resumable in memory.
+      return;
+    }
+
+    const payload: SessionHaltedPayload = {
+      type: "session-halted",
+      sessionId,
+      projectId,
+      projectName: this.getProjectName(projectId),
+      reason,
+      duration: process
+        ? Math.max(0, Date.now() - process.startedAt.getTime())
+        : 0,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      const connectedIds =
+        this.connectedBrowsers?.getConnectedBrowserProfileIds() ?? [];
+      if (connectedIds.length > 0) {
+        console.log(
+          `[PushNotifier] Skipping halted push for ${connectedIds.length} connected browser profile(s)`,
+        );
+      }
+
+      const results = await this.pushService.sendToAll(payload, {
+        excludeBrowserProfileIds: connectedIds,
+      });
+      const successCount = results.filter((r) => r.success).length;
+      if (successCount > 0) {
+        console.log(
+          `[PushNotifier] Sent session-halted notification (${reason}) to ${successCount}/${results.length} devices`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        "[PushNotifier] Failed to send session-halted notification:",
+        error,
+      );
     }
   }
 

--- a/packages/server/test/push/PushNotifier.test.ts
+++ b/packages/server/test/push/PushNotifier.test.ts
@@ -8,6 +8,7 @@ import type {
   BusEvent,
   EventBus,
   ProcessStateEvent,
+  ProcessTerminatedEvent,
 } from "../../src/watcher/EventBus.js";
 
 describe("PushNotifier", () => {
@@ -569,6 +570,118 @@ describe("PushNotifier", () => {
       expect(mockPushService.sendToAll).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("session halted notifications", () => {
+    it("should send session-halted when a live process transitions to idle", async () => {
+      const mockProcess = {
+        startedAt: new Date("2026-04-02T12:00:00.000Z"),
+        state: {
+          type: "idle",
+        } as ProcessState,
+      };
+
+      vi.mocked(mockSupervisor.getProcessForSession).mockReturnValue(
+        mockProcess as unknown as ReturnType<
+          Supervisor["getProcessForSession"]
+        >,
+      );
+
+      new PushNotifier({
+        eventBus: mockEventBus,
+        pushService: mockPushService,
+        supervisor: mockSupervisor,
+      });
+
+      const event: ProcessStateEvent = {
+        type: "process-state-changed",
+        sessionId: "session-1",
+        projectId: testProjectId,
+        activity: "idle",
+        timestamp: new Date().toISOString(),
+      };
+
+      eventHandler?.(event);
+
+      await vi.waitFor(() => {
+        expect(mockPushService.sendToAll).toHaveBeenCalledTimes(1);
+      });
+
+      const payload = vi.mocked(mockPushService.sendToAll).mock.calls[0][0];
+      expect(payload.type).toBe("session-halted");
+      expect(payload.sessionId).toBe("session-1");
+      expect(payload.projectId).toBe(testProjectId);
+      expect(payload.projectName).toBe("test-project");
+      expect(payload.reason).toBe("completed");
+      expect(payload.duration).toEqual(expect.any(Number));
+    });
+
+    it("should ignore idle events after the process has already been unregistered", async () => {
+      vi.mocked(mockSupervisor.getProcessForSession).mockReturnValue(undefined);
+
+      new PushNotifier({
+        eventBus: mockEventBus,
+        pushService: mockPushService,
+        supervisor: mockSupervisor,
+      });
+
+      const event: ProcessStateEvent = {
+        type: "process-state-changed",
+        sessionId: "session-1",
+        projectId: testProjectId,
+        activity: "idle",
+        timestamp: new Date().toISOString(),
+      };
+
+      eventHandler?.(event);
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(mockPushService.sendToAll).not.toHaveBeenCalled();
+    });
+
+    it("should send session-halted with error reason when a process terminates", async () => {
+      const mockProcess = {
+        startedAt: new Date("2026-04-02T12:00:00.000Z"),
+        state: {
+          type: "in-turn",
+        } as ProcessState,
+      };
+
+      vi.mocked(mockSupervisor.getProcessForSession).mockReturnValue(
+        mockProcess as unknown as ReturnType<
+          Supervisor["getProcessForSession"]
+        >,
+      );
+
+      new PushNotifier({
+        eventBus: mockEventBus,
+        pushService: mockPushService,
+        supervisor: mockSupervisor,
+      });
+
+      const event: ProcessTerminatedEvent = {
+        type: "process-terminated",
+        sessionId: "session-1",
+        projectId: testProjectId,
+        processId: "proc-1",
+        provider: "codex",
+        reason: "underlying process terminated",
+        timestamp: new Date().toISOString(),
+      };
+
+      eventHandler?.(event);
+
+      await vi.waitFor(() => {
+        expect(mockPushService.sendToAll).toHaveBeenCalledTimes(1);
+      });
+
+      const payload = vi.mocked(mockPushService.sendToAll).mock.calls[0][0];
+      expect(payload.type).toBe("session-halted");
+      expect(payload.sessionId).toBe("session-1");
+      expect(payload.reason).toBe("error");
+      expect(payload.duration).toEqual(expect.any(Number));
     });
   });
 


### PR DESCRIPTION
## Summary
- send `session-halted` push notifications when a live session reaches `idle`
- send `session-halted` notifications with `error` reason when the underlying process terminates
- ignore the synthetic `idle` emitted during unregister so completion pushes only fire for still-live processes

## Testing
- `corepack pnpm --filter @yep-anywhere/server test -- test/push/PushNotifier.test.ts`
- `corepack pnpm --filter @yep-anywhere/server test -- test/webhooks/LifecycleWebhookService.test.ts`