### PR TITLE
fix(server): avoid rescanning provider catalogs for session lists

### DIFF
--- a/packages/server/src/projects/scanner.ts
+++ b/packages/server/src/projects/scanner.ts
@@ -181,6 +181,8 @@ export class ProjectScanner {
       mergedSessionDirs: project.mergedSessionDirs
         ? [...project.mergedSessionDirs]
         : undefined,
+      hasCodexSessions: project.hasCodexSessions,
+      hasGeminiSessions: project.hasGeminiSessions,
     };
   }
 
@@ -268,6 +270,8 @@ export class ProjectScanner {
           name: basename(projectPath),
           sessionCount,
           sessionDir,
+          hasCodexSessions: false,
+          hasGeminiSessions: false,
           activeOwnedCount: 0, // populated by route
           activeExternalCount: 0, // populated by route
           lastActivity,
@@ -325,14 +329,21 @@ export class ProjectScanner {
       const codexProjects = await this.codexScanner.listProjects();
       for (const codexProject of codexProjects) {
         const projectPath = canonicalizeProjectPath(codexProject.path);
-        // Skip if we've already seen this path from Claude
-        if (seenPaths.has(projectPath)) continue;
+        const existing = projects.find(
+          (project) => canonicalizeProjectPath(project.path) === projectPath,
+        );
+        if (existing) {
+          existing.hasCodexSessions = true;
+          continue;
+        }
         seenPaths.add(projectPath);
         projects.push({
           ...codexProject,
           id: encodeProjectId(projectPath),
           path: projectPath,
           name: basename(projectPath),
+          hasCodexSessions: true,
+          hasGeminiSessions: false,
         });
       }
     }
@@ -345,15 +356,21 @@ export class ProjectScanner {
       const geminiProjects = await this.geminiScanner.listProjects();
       for (const geminiProject of geminiProjects) {
         const projectPath = canonicalizeProjectPath(geminiProject.path);
-        // Skip if we've already seen this path from Claude/Codex
-        // (Gemini projects with unknown hashes will have paths like "gemini:xxxxxxxx")
-        if (seenPaths.has(projectPath)) continue;
+        const existing = projects.find(
+          (project) => canonicalizeProjectPath(project.path) === projectPath,
+        );
+        if (existing) {
+          existing.hasGeminiSessions = true;
+          continue;
+        }
         seenPaths.add(projectPath);
         projects.push({
           ...geminiProject,
           id: encodeProjectId(projectPath),
           path: projectPath,
           name: basename(projectPath),
+          hasCodexSessions: false,
+          hasGeminiSessions: true,
         });
       }
     }
@@ -383,6 +400,8 @@ export class ProjectScanner {
           name: basename(projectPath),
           sessionCount: 0,
           sessionDir: join(this.projectsDir, encodedPath),
+          hasCodexSessions: false,
+          hasGeminiSessions: false,
           activeOwnedCount: 0,
           activeExternalCount: 0,
           lastActivity: metadata.addedAt,

--- a/packages/server/src/routes/global-sessions.ts
+++ b/packages/server/src/routes/global-sessions.ts
@@ -180,6 +180,7 @@ export function createGlobalSessionsRoutes(deps: GlobalSessionsDeps): Hono {
     const projects = await deps.scanner.listProjects();
     const stats: GlobalSessionStats = createEmptyStats();
     const providerCatalog = await buildProviderProjectCatalog({
+      projects,
       codexScanner: deps.codexScanner,
       geminiScanner: deps.geminiScanner,
     });
@@ -288,6 +289,7 @@ export function createGlobalSessionsRoutes(deps: GlobalSessionsDeps): Hono {
     // Collect all sessions with enriched data
     const allSessions: GlobalSessionItem[] = [];
     const providerCatalog = await buildProviderProjectCatalog({
+      projects: allProjects,
       codexScanner: deps.codexScanner,
       geminiScanner: deps.geminiScanner,
     });

--- a/packages/server/src/routes/projects.ts
+++ b/packages/server/src/routes/projects.ts
@@ -337,6 +337,7 @@ export function createProjectsRoutes(deps: ProjectsDeps): Hono {
     }
 
     const providerCatalog = await buildProviderProjectCatalog({
+      projects: [project],
       codexScanner: deps.codexScanner,
       geminiScanner: deps.geminiScanner,
     });

--- a/packages/server/src/routes/provider-catalog.ts
+++ b/packages/server/src/routes/provider-catalog.ts
@@ -1,10 +1,12 @@
 import type { CodexSessionScanner } from "../projects/codex-scanner.js";
 import type { GeminiSessionScanner } from "../projects/gemini-scanner.js";
 import { canonicalizeProjectPath } from "../projects/paths.js";
+import type { Project } from "../supervisor/types.js";
 
 export interface ProviderCatalogDeps {
   codexScanner?: CodexSessionScanner;
   geminiScanner?: GeminiSessionScanner;
+  projects?: Project[];
 }
 
 export interface ProviderProjectCatalog {
@@ -20,6 +22,76 @@ export interface ProviderProjectCatalog {
 export async function buildProviderProjectCatalog(
   deps: ProviderCatalogDeps,
 ): Promise<ProviderProjectCatalog> {
+  if (deps.projects) {
+    const codexPaths = new Set(
+      deps.projects
+        .filter(
+          (project) =>
+            project.hasCodexSessions === true ||
+            project.provider === "codex" ||
+            project.provider === "codex-oss",
+        )
+        .map((project) => canonicalizeProjectPath(project.path)),
+    );
+    const geminiPaths = new Set(
+      deps.projects
+        .filter(
+          (project) =>
+            project.hasGeminiSessions === true ||
+            project.provider === "gemini" ||
+            project.provider === "gemini-acp",
+        )
+        .map((project) => canonicalizeProjectPath(project.path))
+        .filter((path) => !path.startsWith("gemini:")),
+    );
+
+    const needsCodexScan = deps.projects.some(
+      (project) =>
+        project.provider !== "codex" &&
+        project.provider !== "codex-oss" &&
+        project.hasCodexSessions === undefined,
+    );
+    const needsGeminiScan = deps.projects.some(
+      (project) =>
+        project.provider !== "gemini" &&
+        project.provider !== "gemini-acp" &&
+        project.hasGeminiSessions === undefined,
+    );
+
+    if (!needsCodexScan && !needsGeminiScan) {
+      return {
+        codexPaths,
+        geminiPaths,
+        geminiHashToCwd: deps.geminiScanner?.getHashToCwd(),
+      };
+    }
+
+    const [codexProjects, geminiProjects] = await Promise.all([
+      needsCodexScan
+        ? deps.codexScanner?.listProjects() ?? Promise.resolve([])
+        : Promise.resolve([]),
+      needsGeminiScan
+        ? deps.geminiScanner?.listProjects() ?? Promise.resolve([])
+        : Promise.resolve([]),
+    ]);
+
+    for (const project of codexProjects) {
+      codexPaths.add(canonicalizeProjectPath(project.path));
+    }
+    for (const project of geminiProjects) {
+      const path = canonicalizeProjectPath(project.path);
+      if (!path.startsWith("gemini:")) {
+        geminiPaths.add(path);
+      }
+    }
+
+    return {
+      codexPaths,
+      geminiPaths,
+      geminiHashToCwd: deps.geminiScanner?.getHashToCwd(),
+    };
+  }
+
   const [codexProjects, geminiProjects] = await Promise.all([
     deps.codexScanner?.listProjects() ?? Promise.resolve([]),
     deps.geminiScanner?.listProjects() ?? Promise.resolve([]),

--- a/packages/server/src/supervisor/types.ts
+++ b/packages/server/src/supervisor/types.ts
@@ -35,6 +35,8 @@ export interface Project {
   sessionCount: number;
   sessionDir: string; // path to session directory (e.g., ~/.claude/projects/hostname/-encoded-path/)
   mergedSessionDirs?: string[]; // additional session dirs from cross-machine duplicates
+  hasCodexSessions?: boolean; // whether this project also has Codex sessions
+  hasGeminiSessions?: boolean; // whether this project also has Gemini sessions
   activeOwnedCount: number; // sessions owned by this server
   activeExternalCount: number; // sessions controlled by external processes
   lastActivity: string | null; // ISO timestamp of most recent session update

--- a/packages/server/test/projects/scanner.test.ts
+++ b/packages/server/test/projects/scanner.test.ts
@@ -3,6 +3,7 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexSessionScanner } from "../../src/projects/codex-scanner.js";
 import { ProjectScanner } from "../../src/projects/scanner.js";
 import { encodeProjectId } from "../../src/supervisor/types.js";
 import { EventBus } from "../../src/watcher/EventBus.js";
@@ -31,6 +32,7 @@ describe("ProjectScanner missing projectsDir", () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(
       tempDirs
         .splice(0)
@@ -193,5 +195,46 @@ describe("ProjectScanner cache", () => {
 
     const afterEvent = await scanner.getProjectBySessionDirSuffix(secondSuffix);
     expect(afterEvent?.id).toBe(encodeProjectId("/home/user/project-two"));
+  });
+
+  it("marks claude projects that also have codex sessions", async () => {
+    const projectsDir = join(tmpdir(), `project-scanner-${randomUUID()}`);
+    tempDirs.push(projectsDir);
+
+    await createClaudeProject(
+      projectsDir,
+      "localhost",
+      "/home/user/project-one",
+      "sess-1",
+    );
+
+    vi.spyOn(CodexSessionScanner.prototype, "listProjects").mockResolvedValue([
+      {
+        id: encodeProjectId("/home/user/project-one"),
+        path: "/home/user/project-one",
+        name: "project-one",
+        sessionCount: 3,
+        sessionDir: "/codex/sessions",
+        activeOwnedCount: 0,
+        activeExternalCount: 0,
+        lastActivity: "2025-01-01T00:00:00.000Z",
+        provider: "codex",
+      },
+    ]);
+
+    const scanner = new ProjectScanner({
+      projectsDir,
+      enableCodex: true,
+      enableGemini: false,
+      cacheTtlMs: 60000,
+    });
+
+    const projects = await scanner.listProjects();
+    expect(projects).toHaveLength(1);
+    expect(projects[0]?.provider).toBe("claude");
+    expect(projects[0]).toMatchObject({
+      path: "/home/user/project-one",
+      hasCodexSessions: true,
+    });
   });
 });

--- a/packages/server/test/routes/global-sessions.test.ts
+++ b/packages/server/test/routes/global-sessions.test.ts
@@ -484,6 +484,66 @@ describe("Global Sessions Routes", () => {
   });
 
   describe("provider catalog", () => {
+    it("reuses provider presence from listed projects before consulting scanners", async () => {
+      const project = {
+        ...createProject("proj1", "project-one", "/sessions/proj1"),
+        hasCodexSessions: true,
+      } as Project;
+      const codexSession = createSession(
+        "codex-sess-1",
+        "proj1",
+        minutesAgo(1),
+        {
+          provider: "codex",
+        },
+      );
+
+      vi.mocked(mockScanner.listProjects).mockResolvedValue([project]);
+      sessionsByDir.set("/sessions/proj1", []);
+
+      const codexScanner = {
+        listProjects: vi.fn(async () => {
+          throw new Error("codex scanner should not be consulted");
+        }),
+      };
+      const codexReader = {
+        listSessions: vi.fn(async () => [codexSession]),
+      } as unknown as ISessionReader;
+      const codexReaderFactory = vi.fn(() => codexReader);
+      const sessionIndexService = {
+        getSessionsWithCache: vi.fn(
+          async (
+            sessionDir: string,
+            _projectId: string,
+            reader: ISessionReader,
+          ) => {
+            if (sessionDir === "/codex/sessions") {
+              expect(reader).toBe(codexReader);
+              return [codexSession];
+            }
+            return reader.listSessions(_projectId as UrlProjectId);
+          },
+        ),
+      } as unknown as SessionIndexService;
+
+      const routes = createGlobalSessionsRoutes({
+        ...getDeps({ sessionIndexService }),
+        codexScanner:
+          codexScanner as unknown as GlobalSessionsDeps["codexScanner"],
+        codexSessionsDir: "/codex/sessions",
+        codexReaderFactory:
+          codexReaderFactory as unknown as GlobalSessionsDeps["codexReaderFactory"],
+      });
+
+      const response = await routes.request("/?project=proj1");
+      expect(response.status).toBe(200);
+      const result = (await response.json()) as GlobalSessionsResponse;
+
+      expect(codexScanner.listProjects).not.toHaveBeenCalled();
+      expect(codexReaderFactory).toHaveBeenCalledWith(project.path);
+      expect(result.sessions.some((s) => s.id === "codex-sess-1")).toBe(true);
+    });
+
     it("builds codex project catalog once and avoids per-project scanner checks", async () => {
       const project1 = createProject("proj1", "project-one", "/sessions/proj1");
       const project2 = createProject("proj2", "project-two", "/sessions/proj2");


### PR DESCRIPTION
## Summary
- reuse provider presence from `scanner.listProjects()` when building provider catalogs for global session and project session routes
- preserve Codex/Gemini presence on merged `Project` records so Claude-backed projects do not trigger redundant provider scans
- add regression tests covering project scanner provider flags and global sessions catalog reuse

## Root Cause
The session list routes were already working from `scanner.listProjects()`, but they still rebuilt provider catalogs by calling Codex/Gemini scanners again. On machines with a large shared Codex session tree, that extra scan adds significant latency to `/api/sessions`.

## Test Plan
- `pnpm --filter @yep-anywhere/server test -- test/routes/global-sessions.test.ts`
- `pnpm --filter @yep-anywhere/server test -- test/projects/scanner.test.ts`
- `pnpm typecheck`
- `pnpm --filter @yep-anywhere/server build`