### PR TITLE
[codex] reduce agents and session first-load blocking

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { ConnectionBar } from "./components/ConnectionBar";
 import { FloatingActionButton } from "./components/FloatingActionButton";
 import { ReloadBanner } from "./components/ReloadBanner";
 import { OnboardingWizard } from "./components/onboarding";
 import { AuthProvider } from "./contexts/AuthContext";
-import { InboxProvider } from "./contexts/InboxContext";
+import { InboxProvider, useInboxContext } from "./contexts/InboxContext";
 import { SchemaValidationProvider } from "./contexts/SchemaValidationContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import { useActivityBusConnection } from "./hooks/useActivityBusConnection";
@@ -14,6 +15,7 @@ import { useOnboarding } from "./hooks/useOnboarding";
 import { useReloadNotifications } from "./hooks/useReloadNotifications";
 import { I18nProvider } from "./i18n";
 import { initClientLogCollection } from "./lib/diagnostics";
+import { shouldEnableInboxForPathname } from "./lib/inboxRouteActivation";
 
 interface Props {
   children: ReactNode;
@@ -23,6 +25,10 @@ interface Props {
  * Inner component that uses hooks requiring InboxContext.
  */
 function AppContent({ children }: Props) {
+  const location = useLocation();
+  const { setEnabled } = useInboxContext();
+  const shouldEnableInbox = shouldEnableInboxForPathname(location.pathname);
+
   // Manage SSE connection based on auth state (prevents 401s on login page)
   useActivityBusConnection();
 
@@ -31,6 +37,10 @@ function AppContent({ children }: Props) {
 
   // Sync notifyInApp setting to service worker on app startup and SW restarts
   useSyncNotifyInAppSetting();
+
+  useEffect(() => {
+    setEnabled(shouldEnableInbox);
+  }, [setEnabled, shouldEnableInbox]);
 
   // Update tab title with needs-attention badge count (uses InboxContext)
   useNeedsAttentionBadge();
@@ -81,7 +91,7 @@ export function App({ children }: Props) {
     <I18nProvider>
       <ToastProvider>
         <AuthProvider>
-          <InboxProvider>
+          <InboxProvider initialEnabled={false}>
             <SchemaValidationProvider>
               <AppContent>{children}</AppContent>
               {!isLoading && showWizard && (

--- a/packages/client/src/RemoteApp.tsx
+++ b/packages/client/src/RemoteApp.tsx
@@ -17,13 +17,13 @@
  */
 
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ConnectionBar } from "./components/ConnectionBar";
 import { FloatingActionButton } from "./components/FloatingActionButton";
 import { HostOfflineModal } from "./components/HostOfflineModal";
 import { ReloadBanner } from "./components/ReloadBanner";
 import { Modal } from "./components/ui/Modal";
-import { InboxProvider } from "./contexts/InboxContext";
+import { InboxProvider, useInboxContext } from "./contexts/InboxContext";
 import {
   RemoteConnectionProvider,
   useRemoteConnection,
@@ -38,6 +38,7 @@ import { useRemoteBasePath } from "./hooks/useRemoteBasePath";
 import { useVersion } from "./hooks/useVersion";
 import { connectionManager } from "./lib/connection";
 import { initClientLogCollection } from "./lib/diagnostics";
+import { shouldEnableInboxForPathname } from "./lib/inboxRouteActivation";
 
 interface Props {
   children: ReactNode;
@@ -205,6 +206,14 @@ export function ConnectionGate() {
  * Must be rendered inside InboxProvider.
  */
 function RemoteAppInner({ children }: Props) {
+  const location = useLocation();
+  const { setEnabled } = useInboxContext();
+  const shouldEnableInbox = shouldEnableInboxForPathname(location.pathname);
+
+  useEffect(() => {
+    setEnabled(shouldEnableInbox);
+  }, [setEnabled, shouldEnableInbox]);
+
   useNeedsAttentionBadge();
 
   return (
@@ -232,7 +241,7 @@ export function RemoteApp({ children }: Props) {
   return (
     <ToastProvider>
       <RemoteConnectionProvider>
-        <InboxProvider>
+        <InboxProvider initialEnabled={false}>
           <SchemaValidationProvider>
             <RemoteAppInner>{children}</RemoteAppInner>
           </SchemaValidationProvider>

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -369,6 +369,14 @@ export const api = {
       body: JSON.stringify({ path }),
     }),
 
+  deleteProject: (projectId: string) =>
+    fetchJSON<{ removed: boolean; projectId: string }>(
+      `/projects/${projectId}`,
+      {
+        method: "DELETE",
+      },
+    ),
+
   getProject: (projectId: string) =>
     fetchJSON<{ project: Project }>(`/projects/${projectId}`),
 
@@ -376,7 +384,11 @@ export const api = {
     projectId: string,
     sessionId: string,
     afterMessageId?: string,
-    options?: { tailCompactions?: number; beforeMessageId?: string },
+    options?: {
+      tailCompactions?: number;
+      beforeMessageId?: string;
+      maxMessages?: number;
+    },
   ) => {
     const params = new URLSearchParams();
     if (afterMessageId) params.set("afterMessageId", afterMessageId);
@@ -384,6 +396,8 @@ export const api = {
       params.set("tailCompactions", String(options.tailCompactions));
     if (options?.beforeMessageId)
       params.set("beforeMessageId", options.beforeMessageId);
+    if (options?.maxMessages !== undefined)
+      params.set("maxMessages", String(options.maxMessages));
     const qs = params.toString();
     return fetchJSON<{
       session: Session;

--- a/packages/client/src/components/RecentSessionsDropdown.tsx
+++ b/packages/client/src/components/RecentSessionsDropdown.tsx
@@ -84,6 +84,7 @@ export function RecentSessionsDropdown({
   const { sessions } = useGlobalSessions({
     limit: MAX_RECENT_SESSIONS + 5,
     includeStats: false,
+    enabled: isOpen,
   });
 
   // Filter out current session and limit

--- a/packages/client/src/components/SessionMenu.tsx
+++ b/packages/client/src/components/SessionMenu.tsx
@@ -28,6 +28,8 @@ export interface SessionMenuProps {
   sharingConfigured?: boolean;
   /** Called to share the session as a snapshot */
   onShare?: () => void | Promise<void>;
+  /** Called when opening the menu, for lazy-loading menu-only state */
+  onOpen?: () => void | Promise<void>;
   /** Additional class for the wrapper */
   className?: string;
   /** Use fixed positioning for dropdown (escapes overflow clipping) */
@@ -50,6 +52,7 @@ export function SessionMenu({
   onTerminate,
   sharingConfigured,
   onShare,
+  onOpen,
   useEllipsisIcon = false,
   className = "",
   useFixedPositioning = false,
@@ -110,6 +113,7 @@ export function SessionMenu({
       setDropdownPosition(null);
       triggerRef.current?.blur();
     } else {
+      void onOpen?.();
       // Calculate position synchronously before opening to avoid flicker
       if (useFixedPositioning && triggerRef.current) {
         const rect = triggerRef.current.getBoundingClientRect();

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ const SWIPE_THRESHOLD = 50; // Minimum distance to trigger close
 const SWIPE_ENGAGE_THRESHOLD = 15; // Minimum horizontal distance before swipe engages
 const RECENT_SESSIONS_INITIAL = 12; // Initial number of recent sessions to show
 const RECENT_SESSIONS_INCREMENT = 10; // How many more to show on each expand
+const SESSION_LIST_DELAY_MS = 750; // Let page-critical data load first
 
 interface SidebarProps {
   isOpen: boolean;
@@ -68,20 +69,29 @@ export function Sidebar({
   const basePath = useRemoteBasePath();
   const navigate = useNavigate();
   const remoteConnection = useOptionalRemoteConnection();
+  const shouldLoadSessionLists = !isDesktop || !isCollapsed;
+  const [sessionListsEnabled, setSessionListsEnabled] = useState(false);
 
-  // Fetch global sessions for sidebar (non-starred only for recent/older sections)
-  const { sessions: globalSessions, loading: globalLoading } =
-    useGlobalSessions({ limit: 50, includeStats: false });
+  useEffect(() => {
+    if (!shouldLoadSessionLists) {
+      setSessionListsEnabled(false);
+      return;
+    }
 
-  // Fetch starred sessions separately to ensure we get ALL starred sessions
-  const { sessions: starredSessions, loading: starredLoading } =
+    const timer = setTimeout(() => {
+      setSessionListsEnabled(true);
+    }, SESSION_LIST_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [shouldLoadSessionLists]);
+
+  // Fetch one shared session list for the expanded sidebar only.
+  const { sessions: sidebarSessions, loading: sessionsLoading } =
     useGlobalSessions({
-      starred: true,
       limit: 100,
       includeStats: false,
+      enabled: sessionListsEnabled,
     });
-
-  const sessionsLoading = globalLoading || starredLoading;
 
   // Server capabilities for feature gating
   const { version: versionInfo } = useVersion();
@@ -209,35 +219,33 @@ export function Sidebar({
     onNavigate();
   };
 
-  // Starred sessions come from dedicated fetch (filtered by server)
-  // Filter out archived just in case
   const filteredStarredSessions = useMemo(() => {
-    return starredSessions.filter((s) => !s.isArchived);
-  }, [starredSessions]);
+    return sidebarSessions.filter((s) => s.isStarred && !s.isArchived);
+  }, [sidebarSessions]);
 
   // Sessions updated in the last 24 hours (non-starred, non-archived)
   const recentDaySessions = useMemo(() => {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     const isWithinLastDay = (date: Date) => date.getTime() >= oneDayAgo;
 
-    return globalSessions.filter(
+    return sidebarSessions.filter(
       (s) =>
         !s.isStarred && !s.isArchived && isWithinLastDay(new Date(s.updatedAt)),
     );
-  }, [globalSessions]);
+  }, [sidebarSessions]);
 
   // Older sessions (non-starred, non-archived, NOT in last 24 hours)
   const olderSessions = useMemo(() => {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     const isOlderThanOneDay = (date: Date) => date.getTime() < oneDayAgo;
 
-    return globalSessions.filter(
+    return sidebarSessions.filter(
       (s) =>
         !s.isStarred &&
         !s.isArchived &&
         isOlderThanOneDay(new Date(s.updatedAt)),
     );
-  }, [globalSessions]);
+  }, [sidebarSessions]);
 
   // Track which sessions have unsent drafts in localStorage
   const drafts = useDrafts();

--- a/packages/client/src/components/SlashCommandButton.tsx
+++ b/packages/client/src/components/SlashCommandButton.tsx
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const DESKTOP_BREAKPOINT = 769;
+const SLASH_COMMAND_LABEL = "Slash commands";
 
 interface SlashCommandButtonProps {
   /** Available slash commands (without the "/" prefix) */
@@ -19,12 +23,29 @@ export function SlashCommandButton({
   disabled,
 }: SlashCommandButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.innerWidth >= DESKTOP_BREAKPOINT,
+  );
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    buttonRef.current?.blur();
+  }, []);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= DESKTOP_BREAKPOINT);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   // Close menu when clicking outside
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !isDesktop) return;
 
     const handleClickOutside = (e: MouseEvent) => {
       if (
@@ -33,13 +54,13 @@ export function SlashCommandButton({
         buttonRef.current &&
         !buttonRef.current.contains(e.target as Node)
       ) {
-        setIsOpen(false);
+        handleClose();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen]);
+  }, [handleClose, isDesktop, isOpen]);
 
   // Close menu on Escape
   useEffect(() => {
@@ -47,27 +68,118 @@ export function SlashCommandButton({
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        setIsOpen(false);
+        handleClose();
         buttonRef.current?.focus();
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleClose, isOpen]);
+
+  // Mobile bottom sheet should prevent background scrolling while open.
+  useEffect(() => {
+    if (isOpen && !isDesktop) {
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = previousOverflow;
+      };
+    }
+  }, [isDesktop, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      menuRef.current?.focus();
+    }
+  }, [isDesktop, isOpen]);
 
   const handleCommandClick = useCallback(
     (command: string) => {
       onSelectCommand(`/${command}`);
-      setIsOpen(false);
+      handleClose();
     },
-    [onSelectCommand],
+    [handleClose, onSelectCommand],
   );
+
+  const handleToggle = useCallback(() => {
+    if (disabled) return;
+
+    if (isOpen) {
+      handleClose();
+      buttonRef.current?.focus();
+      return;
+    }
+
+    buttonRef.current?.blur();
+    setIsOpen(true);
+  }, [disabled, handleClose, isOpen]);
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      e.preventDefault();
+      e.stopPropagation();
+      handleClose();
+    }
+  };
 
   // Don't render if no commands available
   if (commands.length === 0) {
     return null;
   }
+
+  const commandItems = commands.map((command) => (
+    <button
+      key={command}
+      type="button"
+      className="slash-command-item"
+      onClick={() => handleCommandClick(command)}
+      role="menuitem"
+    >
+      /{command}
+    </button>
+  ));
+
+  const desktopMenu =
+    isOpen && isDesktop ? (
+      <div
+        ref={menuRef}
+        className="slash-command-menu"
+        role="menu"
+        aria-label={SLASH_COMMAND_LABEL}
+        tabIndex={-1}
+      >
+        {commandItems}
+      </div>
+    ) : null;
+
+  const mobileSheet =
+    isOpen && !isDesktop
+      ? createPortal(
+          // biome-ignore lint/a11y/useKeyWithClickEvents: Escape key handled globally
+          <div
+            className="slash-command-overlay"
+            onClick={handleOverlayClick}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div
+              ref={menuRef}
+              className="slash-command-sheet"
+              role="menu"
+              aria-label={SLASH_COMMAND_LABEL}
+              tabIndex={-1}
+            >
+              <div className="slash-command-header">
+                <span className="slash-command-title">
+                  {SLASH_COMMAND_LABEL}
+                </span>
+              </div>
+              <div className="slash-command-sheet-list">{commandItems}</div>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <div className="slash-command-container">
@@ -75,35 +187,17 @@ export function SlashCommandButton({
         ref={buttonRef}
         type="button"
         className={`slash-command-button ${isOpen ? "active" : ""}`}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         disabled={disabled}
-        title="Slash commands"
+        title={SLASH_COMMAND_LABEL}
         aria-label="Show slash commands"
         aria-expanded={isOpen}
         aria-haspopup="menu"
       >
         <span className="slash-icon">/</span>
       </button>
-      {isOpen && (
-        <div
-          ref={menuRef}
-          className="slash-command-menu"
-          role="menu"
-          aria-label="Slash commands"
-        >
-          {commands.map((command) => (
-            <button
-              key={command}
-              type="button"
-              className="slash-command-item"
-              onClick={() => handleCommandClick(command)}
-              role="menuitem"
-            >
-              /{command}
-            </button>
-          ))}
-        </div>
-      )}
+      {desktopMenu}
+      {mobileSheet}
     </div>
   );
 }

--- a/packages/client/src/components/__tests__/SlashCommandButton.test.tsx
+++ b/packages/client/src/components/__tests__/SlashCommandButton.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SlashCommandButton } from "../SlashCommandButton";
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+describe("SlashCommandButton", () => {
+  beforeEach(() => {
+    setViewportWidth(1024);
+    document.body.style.overflow = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+    setViewportWidth(ORIGINAL_INNER_WIDTH);
+    document.body.style.overflow = "";
+    vi.restoreAllMocks();
+  });
+
+  it("opens an inline desktop menu and inserts the selected command", () => {
+    const onSelectCommand = vi.fn();
+
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={onSelectCommand}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+
+    const menu = screen.getByRole("menu", { name: "Slash commands" });
+    expect(menu.className).toContain("slash-command-menu");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "/docs" }));
+
+    expect(onSelectCommand).toHaveBeenCalledWith("/docs");
+    expect(screen.queryByRole("menu", { name: "Slash commands" })).toBeNull();
+  });
+
+  it("renders a mobile bottom sheet and restores body scroll after selection", () => {
+    const onSelectCommand = vi.fn();
+    setViewportWidth(390);
+
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={onSelectCommand}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+
+    const menu = screen.getByRole("menu", { name: "Slash commands" });
+    expect(menu.className).toContain("slash-command-sheet");
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "/defuddle" }));
+
+    expect(onSelectCommand).toHaveBeenCalledWith("/defuddle");
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("closes the desktop menu when clicking outside", () => {
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+    expect(screen.getByRole("menu", { name: "Slash commands" })).not.toBeNull();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole("menu", { name: "Slash commands" })).toBeNull();
+  });
+});

--- a/packages/client/src/hooks/useGlobalActiveAgents.ts
+++ b/packages/client/src/hooks/useGlobalActiveAgents.ts
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { api } from "../api/client";
+import { fetchJSON } from "../api/client";
 import { useFileActivity } from "./useFileActivity";
 
 // Debounce interval for refetch on SSE events
 const REFETCH_DEBOUNCE_MS = 500;
+
+interface ProcessesResponse {
+  processes: Array<{ state: string }>;
+}
 
 /**
  * Hook that monitors the global count of active agents (running processes).
@@ -16,8 +20,13 @@ export function useGlobalActiveAgents() {
   // Fetch just the active count
   const fetchCount = useCallback(async () => {
     try {
-      const data = await api.getInbox();
-      setCount(data.active.length);
+      const data = await fetchJSON<ProcessesResponse>("/processes");
+      setCount(
+        data.processes.filter(
+          (process) =>
+            process.state === "in-turn" || process.state === "waiting-input",
+        ).length,
+      );
     } catch {
       // Silently ignore errors - indicator is non-critical
     }

--- a/packages/client/src/hooks/useGlobalSessions.ts
+++ b/packages/client/src/hooks/useGlobalSessions.ts
@@ -24,6 +24,7 @@ export interface UseGlobalSessionsOptions {
   includeArchived?: boolean;
   starred?: boolean;
   includeStats?: boolean;
+  enabled?: boolean;
 }
 
 /** Default stats when no data loaded */
@@ -44,6 +45,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     includeArchived,
     starred,
     includeStats = false,
+    enabled = true,
   } = options;
   const [sessions, setSessions] = useState<GlobalSessionItem[]>([]);
   const [stats, setStats] = useState<GlobalSessionStats>(DEFAULT_STATS);
@@ -69,13 +71,25 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
   }>({});
 
   const fetch = useCallback(async () => {
+    if (!enabled) {
+      setSessions([]);
+      setStats(DEFAULT_STATS);
+      setProjects([]);
+      setHasMore(false);
+      setError(null);
+      setLoading(false);
+      hasInitialLoadRef.current = false;
+      return;
+    }
+
     // Reset initial load flag when options change
     const optionsChanged =
       lastFetchOptionsRef.current.projectId !== projectId ||
       lastFetchOptionsRef.current.searchQuery !== searchQuery ||
       lastFetchOptionsRef.current.includeArchived !== includeArchived ||
       lastFetchOptionsRef.current.starred !== starred ||
-      lastFetchOptionsRef.current.includeStats !== includeStats;
+      lastFetchOptionsRef.current.includeStats !== includeStats ||
+      lastFetchOptionsRef.current.enabled !== enabled;
 
     if (optionsChanged) {
       hasInitialLoadRef.current = false;
@@ -88,6 +102,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
       includeArchived,
       starred,
       includeStats,
+      enabled,
     };
 
     // Only show loading state on initial load
@@ -148,11 +163,19 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     } finally {
       setLoading(false);
     }
-  }, [projectId, searchQuery, limit, includeArchived, starred, includeStats]);
+  }, [
+    enabled,
+    projectId,
+    searchQuery,
+    limit,
+    includeArchived,
+    starred,
+    includeStats,
+  ]);
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
-    if (!hasMore || sessions.length === 0) return;
+    if (!enabled || !hasMore || sessions.length === 0) return;
 
     const lastSession = sessions[sessions.length - 1];
     if (!lastSession) return;
@@ -187,6 +210,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     limit,
     includeArchived,
     starred,
+    enabled,
   ]);
 
   // Debounced refetch

--- a/packages/client/src/hooks/useProcesses.ts
+++ b/packages/client/src/hooks/useProcesses.ts
@@ -54,9 +54,7 @@ export function useProcesses() {
   const fetchProcesses = useCallback(async (includeTerminated = false) => {
     try {
       const data = await fetchJSON<ProcessesResponse>(
-        includeTerminated
-          ? "/processes?includeTerminated=true"
-          : "/processes",
+        includeTerminated ? "/processes?includeTerminated=true" : "/processes",
       );
       setProcesses(data.processes);
       if (includeTerminated) {

--- a/packages/client/src/hooks/useProcesses.ts
+++ b/packages/client/src/hooks/useProcesses.ts
@@ -51,13 +51,17 @@ export function useProcesses() {
   const [error, setError] = useState<Error | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetchProcesses = useCallback(async () => {
+  const fetchProcesses = useCallback(async (includeTerminated = false) => {
     try {
       const data = await fetchJSON<ProcessesResponse>(
-        "/processes?includeTerminated=true",
+        includeTerminated
+          ? "/processes?includeTerminated=true"
+          : "/processes",
       );
       setProcesses(data.processes);
-      setTerminatedProcesses(data.terminatedProcesses ?? []);
+      if (includeTerminated) {
+        setTerminatedProcesses(data.terminatedProcesses ?? []);
+      }
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));
@@ -69,11 +73,15 @@ export function useProcesses() {
   // Initial fetch
   useEffect(() => {
     fetchProcesses();
+    void fetchProcesses(true);
   }, [fetchProcesses]);
 
-  // Polling
+  // Poll only the active processes. The terminated list is informational and
+  // doesn't need to block navigation or refresh every interval.
   useEffect(() => {
-    pollTimerRef.current = setInterval(fetchProcesses, POLL_INTERVAL_MS);
+    pollTimerRef.current = setInterval(() => {
+      void fetchProcesses();
+    }, POLL_INTERVAL_MS);
     return () => {
       if (pollTimerRef.current) {
         clearInterval(pollTimerRef.current);

--- a/packages/client/src/hooks/useProjects.ts
+++ b/packages/client/src/hooks/useProjects.ts
@@ -3,6 +3,45 @@ import { api } from "../api/client";
 import type { Project } from "../types";
 import { type SessionStatusEvent, useFileActivity } from "./useFileActivity";
 
+interface SharedProjectsState {
+  projects: Project[];
+  error: Error | null;
+}
+
+let sharedProjectsState: SharedProjectsState = {
+  projects: [],
+  error: null,
+};
+
+let sharedProjectsInflight: Promise<SharedProjectsState> | null = null;
+
+async function fetchSharedProjects(): Promise<SharedProjectsState> {
+  if (sharedProjectsInflight) {
+    return sharedProjectsInflight;
+  }
+
+  sharedProjectsInflight = (async () => {
+    try {
+      const data = await api.getProjects();
+      sharedProjectsState = {
+        projects: data.projects,
+        error: null,
+      };
+    } catch (err) {
+      sharedProjectsState = {
+        projects: sharedProjectsState.projects,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    } finally {
+      sharedProjectsInflight = null;
+    }
+
+    return sharedProjectsState;
+  })();
+
+  return sharedProjectsInflight;
+}
+
 /**
  * Fetch a single project by ID.
  */
@@ -57,27 +96,23 @@ export function useProject(projectId: string | undefined) {
 const REFETCH_DEBOUNCE_MS = 500;
 
 export function useProjects() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const [projects, setProjects] = useState<Project[]>(sharedProjectsState.projects);
+  const [loading, setLoading] = useState(sharedProjectsState.projects.length === 0);
+  const [error, setError] = useState<Error | null>(sharedProjectsState.error);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasFetchedRef = useRef(false);
-  const hasResolvedInitialFetchRef = useRef(false);
+  const hasResolvedInitialFetchRef = useRef(sharedProjectsState.projects.length > 0);
 
   const fetch = useCallback(async () => {
     // Preserve existing UI during background refetches triggered by activity
     // events so pages don't bounce back to their initial loading state.
     setLoading(!hasResolvedInitialFetchRef.current);
     setError(null);
-    try {
-      const data = await api.getProjects();
-      setProjects(data.projects);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      hasResolvedInitialFetchRef.current = true;
-      setLoading(false);
-    }
+    const nextState = await fetchSharedProjects();
+    setProjects(nextState.projects);
+    setError(nextState.error);
+    hasResolvedInitialFetchRef.current = true;
+    setLoading(false);
   }, []);
 
   // Initial fetch - only once (avoid StrictMode double-fetch)

--- a/packages/client/src/hooks/useProjects.ts
+++ b/packages/client/src/hooks/useProjects.ts
@@ -96,12 +96,18 @@ export function useProject(projectId: string | undefined) {
 const REFETCH_DEBOUNCE_MS = 500;
 
 export function useProjects() {
-  const [projects, setProjects] = useState<Project[]>(sharedProjectsState.projects);
-  const [loading, setLoading] = useState(sharedProjectsState.projects.length === 0);
+  const [projects, setProjects] = useState<Project[]>(
+    sharedProjectsState.projects,
+  );
+  const [loading, setLoading] = useState(
+    sharedProjectsState.projects.length === 0,
+  );
   const [error, setError] = useState<Error | null>(sharedProjectsState.error);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasFetchedRef = useRef(false);
-  const hasResolvedInitialFetchRef = useRef(sharedProjectsState.projects.length > 0);
+  const hasResolvedInitialFetchRef = useRef(
+    sharedProjectsState.projects.length > 0,
+  );
 
   const fetch = useCallback(async () => {
     // Preserve existing UI during background refetches triggered by activity

--- a/packages/client/src/hooks/useSessionMessages.ts
+++ b/packages/client/src/hooks/useSessionMessages.ts
@@ -13,6 +13,9 @@ import {
 import { getProvider } from "../providers/registry";
 import type { Message, Session, SessionStatus } from "../types";
 
+const INITIAL_SESSION_TAIL_COMPACTIONS = 1;
+const INITIAL_SESSION_MAX_MESSAGES = 400;
+
 /** Content from a subagent (Task tool) */
 export interface AgentContent {
   messages: Message[];
@@ -295,7 +298,10 @@ export function useSessionMessages(
     setAgentContent({});
 
     api
-      .getSession(projectId, sessionId, undefined, { tailCompactions: 2 })
+      .getSession(projectId, sessionId, undefined, {
+        tailCompactions: INITIAL_SESSION_TAIL_COMPACTIONS,
+        maxMessages: INITIAL_SESSION_MAX_MESSAGES,
+      })
       .then((data) => {
         setSession(data.session);
         setPagination(data.pagination);
@@ -479,8 +485,9 @@ export function useSessionMessages(
     setLoadingOlder(true);
     try {
       const data = await api.getSession(projectId, sessionId, undefined, {
-        tailCompactions: 2,
+        tailCompactions: INITIAL_SESSION_TAIL_COMPACTIONS,
         beforeMessageId: pagination.truncatedBeforeMessageId,
+        maxMessages: INITIAL_SESSION_MAX_MESSAGES,
       });
       setMessages((prev) => {
         const taggedOlder = data.messages.map((m) => ({

--- a/packages/client/src/hooks/useSessionMessages.ts
+++ b/packages/client/src/hooks/useSessionMessages.ts
@@ -14,7 +14,7 @@ import { getProvider } from "../providers/registry";
 import type { Message, Session, SessionStatus } from "../types";
 
 const INITIAL_SESSION_TAIL_COMPACTIONS = 1;
-const INITIAL_SESSION_MAX_MESSAGES = 400;
+const INITIAL_SESSION_MAX_MESSAGES = 300;
 
 /** Content from a subagent (Task tool) */
 export interface AgentContent {

--- a/packages/client/src/lib/inboxRouteActivation.ts
+++ b/packages/client/src/lib/inboxRouteActivation.ts
@@ -1,0 +1,6 @@
+export function shouldEnableInboxForPathname(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+
+  return lastSegment === "projects" || lastSegment === "inbox";
+}

--- a/packages/client/src/pages/SessionPage.tsx
+++ b/packages/client/src/pages/SessionPage.tsx
@@ -27,7 +27,6 @@ import type { DraftControls } from "../hooks/useDraftPersistence";
 import { useEngagementTracking } from "../hooks/useEngagementTracking";
 import { getModelSetting, getThinkingSetting } from "../hooks/useModelSettings";
 import { useProject } from "../hooks/useProjects";
-import { useProviders } from "../hooks/useProviders";
 import { recordSessionVisit } from "../hooks/useRecentSessions";
 import { useRemoteBasePath } from "../hooks/useRemoteBasePath";
 import {
@@ -37,6 +36,7 @@ import {
 import { useI18n } from "../i18n";
 import { useNavigationLayout } from "../layouts";
 import { preprocessMessages } from "../lib/preprocessMessages";
+import { getProvider } from "../providers/registry";
 import { generateUUID } from "../lib/uuid";
 import { getSessionDisplayTitle } from "../utils";
 
@@ -206,19 +206,16 @@ function SessionPageContent({
     return slashCommands;
   }, [slashCommands, status.owner]);
 
-  // Get provider capabilities based on session's provider
-  const { providers } = useProviders();
-  const currentProviderInfo = useMemo(() => {
-    if (!session?.provider) return null;
-    return providers.find((p) => p.name === session.provider) ?? null;
-  }, [providers, session?.provider]);
-  // Default to true for backwards compatibility (except slash commands)
+  const currentProvider = useMemo(
+    () => getProvider(session?.provider ?? initialProvider),
+    [initialProvider, session?.provider],
+  );
   const supportsPermissionMode =
-    currentProviderInfo?.supportsPermissionMode ?? true;
+    currentProvider.capabilities.supportsPermissionMode;
   const supportsThinkingToggle =
-    currentProviderInfo?.supportsThinkingToggle ?? true;
+    currentProvider.capabilities.supportsThinkingToggle;
   const supportsSlashCommands =
-    currentProviderInfo?.supportsSlashCommands ?? false;
+    currentProvider.capabilities.supportsSlashCommands;
 
   // Inline title editing state
   const [isEditingTitle, setIsEditingTitle] = useState(false);

--- a/packages/client/src/pages/SessionPage.tsx
+++ b/packages/client/src/pages/SessionPage.tsx
@@ -186,12 +186,15 @@ function SessionPageContent({
 
   // Sharing: check if configured (hidden unless sharing.json exists on server)
   const [sharingConfigured, setSharingConfigured] = useState(false);
-  useEffect(() => {
-    api
+  const [sharingStatusChecked, setSharingStatusChecked] = useState(false);
+  const ensureSharingStatus = useCallback(() => {
+    if (sharingStatusChecked) return;
+    setSharingStatusChecked(true);
+    void api
       .getSharingStatus()
       .then((res) => setSharingConfigured(res.configured))
       .catch(() => {});
-  }, []);
+  }, [sharingStatusChecked]);
 
   // Connection for uploads (uses WebSocket when enabled)
   const connection = useConnection();
@@ -1025,6 +1028,7 @@ function SessionPageContent({
                     onTerminate={handleTerminate}
                     sharingConfigured={sharingConfigured}
                     onShare={handleShare}
+                    onOpen={ensureSharingStatus}
                     useFixedPositioning
                     useEllipsisIcon
                   />

--- a/packages/client/src/providers/implementations/ClaudeOllamaProvider.ts
+++ b/packages/client/src/providers/implementations/ClaudeOllamaProvider.ts
@@ -11,6 +11,9 @@ export class ClaudeOllamaProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: true,
     supportsCloning: true,
+    supportsPermissionMode: true,
+    supportsThinkingToggle: true,
+    supportsSlashCommands: true,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/implementations/ClaudeProvider.ts
+++ b/packages/client/src/providers/implementations/ClaudeProvider.ts
@@ -11,6 +11,9 @@ export class ClaudeProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: true,
     supportsCloning: true,
+    supportsPermissionMode: true,
+    supportsThinkingToggle: true,
+    supportsSlashCommands: true,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/implementations/CodexProvider.ts
+++ b/packages/client/src/providers/implementations/CodexProvider.ts
@@ -11,6 +11,9 @@ export class CodexProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: false, // Linear history
     supportsCloning: true,
+    supportsPermissionMode: true,
+    supportsThinkingToggle: true,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata = {
@@ -32,6 +35,9 @@ export class CodexOssProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: false, // Linear history
     supportsCloning: true,
+    supportsPermissionMode: false,
+    supportsThinkingToggle: false,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/implementations/GeminiACPProvider.ts
+++ b/packages/client/src/providers/implementations/GeminiACPProvider.ts
@@ -17,6 +17,9 @@ export class GeminiACPProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: false,
     supportsCloning: false,
+    supportsPermissionMode: true,
+    supportsThinkingToggle: false,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/implementations/GeminiProvider.ts
+++ b/packages/client/src/providers/implementations/GeminiProvider.ts
@@ -11,6 +11,9 @@ export class GeminiProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: false,
     supportsCloning: false,
+    supportsPermissionMode: false,
+    supportsThinkingToggle: false,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/implementations/OpenCodeProvider.ts
+++ b/packages/client/src/providers/implementations/OpenCodeProvider.ts
@@ -11,6 +11,9 @@ export class OpenCodeProvider implements Provider {
   readonly capabilities: ProviderCapabilities = {
     supportsDag: false,
     supportsCloning: false,
+    supportsPermissionMode: false,
+    supportsThinkingToggle: false,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata = {

--- a/packages/client/src/providers/registry.ts
+++ b/packages/client/src/providers/registry.ts
@@ -34,6 +34,9 @@ class GenericProvider implements Provider {
   readonly capabilities = {
     supportsDag: false,
     supportsCloning: false,
+    supportsPermissionMode: false,
+    supportsThinkingToggle: false,
+    supportsSlashCommands: false,
   };
 
   readonly metadata: ProviderMetadata;

--- a/packages/client/src/providers/types.ts
+++ b/packages/client/src/providers/types.ts
@@ -14,6 +14,21 @@ export interface ProviderCapabilities {
    * Whether the provider supports cloning sessions.
    */
   supportsCloning: boolean;
+
+  /**
+   * Whether the provider supports permission mode switching.
+   */
+  supportsPermissionMode: boolean;
+
+  /**
+   * Whether the provider supports the thinking toggle.
+   */
+  supportsThinkingToggle: boolean;
+
+  /**
+   * Whether the provider exposes slash commands.
+   */
+  supportsSlashCommands: boolean;
 }
 
 /**

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -2409,6 +2409,7 @@ a.sidebar-nav-item {
 /* Slash command button */
 .slash-command-container {
   position: relative;
+  flex-shrink: 0;
 }
 
 .slash-command-button {
@@ -2448,18 +2449,7 @@ a.sidebar-nav-item {
 }
 
 .slash-command-menu {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  margin-bottom: var(--space-1);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  min-width: 160px;
-  max-height: 240px;
-  overflow-y: auto;
-  z-index: 100;
+  display: none;
 }
 
 .slash-command-item {
@@ -2490,6 +2480,85 @@ a.sidebar-nav-item {
 
 .slash-command-item:only-child {
   border-radius: var(--radius-md);
+}
+
+.slash-command-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10001;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.slash-command-sheet {
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: slashCommandSlideUp 0.2s ease-out;
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+@keyframes slashCommandSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.slash-command-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.slash-command-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.slash-command-sheet-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) 0;
+}
+
+.slash-command-sheet .slash-command-item {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
+}
+
+@media (min-width: 769px) {
+  .slash-command-menu {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+    right: 0;
+    margin-bottom: var(--space-1);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+    max-width: min(18rem, calc(100vw - 1rem));
+    max-height: 240px;
+    overflow-y: auto;
+    z-index: 100;
+  }
+
+  .slash-command-overlay {
+    display: none;
+  }
 }
 
 /* Attachment list */

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -525,15 +525,21 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
   //   ?afterMessageId=<id> - incremental forward-fetch (append new messages)
   //   ?tailCompactions=<n> - return only last N compact boundaries worth of messages
   //   ?beforeMessageId=<id> - cursor for loading older chunks (used with tailCompactions)
+  //   ?maxMessages=<n> - cap the returned message count after compact-boundary slicing
   routes.get("/projects/:projectId/sessions/:sessionId", async (c) => {
     const projectId = c.req.param("projectId");
     const sessionId = c.req.param("sessionId");
     const afterMessageId = c.req.query("afterMessageId");
     const tailCompactionsParam = c.req.query("tailCompactions");
     const beforeMessageId = c.req.query("beforeMessageId");
+    const maxMessagesParam = c.req.query("maxMessages");
     const tailCompactions =
       tailCompactionsParam !== undefined
         ? Number.parseInt(tailCompactionsParam, 10)
+        : undefined;
+    const maxMessages =
+      maxMessagesParam !== undefined
+        ? Number.parseInt(maxMessagesParam, 10)
         : undefined;
 
     // Validate projectId format at API boundary
@@ -738,6 +744,7 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
         session.messages,
         tailCompactions,
         beforeMessageId,
+        maxMessages,
       );
       session = { ...session, messages: sliced.messages };
       paginationInfo = sliced.pagination;

--- a/packages/server/src/sessions/pagination.ts
+++ b/packages/server/src/sessions/pagination.ts
@@ -50,6 +50,7 @@ export function sliceAtCompactBoundaries(
   messages: Message[],
   tailCompactions: number,
   beforeMessageId?: string,
+  maxMessages?: number,
 ): SliceResult {
   const totalMessageCount = messages.length;
 
@@ -74,32 +75,49 @@ export function sliceAtCompactBoundaries(
 
   const totalCompactions = compactIndices.length;
 
-  // If fewer or equal compactions than requested, return everything
+  let slicedMessages: Message[];
+  let hasOlderMessages = compactIndices.length > tailCompactions;
+
+  // If fewer or equal compactions than requested, start from the full working set
   if (compactIndices.length <= tailCompactions) {
+    slicedMessages = workingMessages;
+  } else {
+    // Slice starting from the Nth-from-last compact boundary (inclusive)
+    const sliceFromIdx =
+      compactIndices[compactIndices.length - tailCompactions] ?? 0;
+    slicedMessages = workingMessages.slice(sliceFromIdx);
+  }
+
+  if (
+    maxMessages !== undefined &&
+    maxMessages > 0 &&
+    slicedMessages.length > maxMessages
+  ) {
+    slicedMessages = slicedMessages.slice(-maxMessages);
+    hasOlderMessages = true;
+  }
+
+  const firstId = slicedMessages[0]
+    ? getMessageId(slicedMessages[0])
+    : undefined;
+
+  if (!hasOlderMessages) {
     return {
-      messages: workingMessages,
+      messages: slicedMessages,
       pagination: {
         hasOlderMessages: false,
         totalMessageCount,
-        returnedMessageCount: workingMessages.length,
+        returnedMessageCount: slicedMessages.length,
         truncatedBeforeMessageId: undefined,
         totalCompactions,
       },
     };
   }
 
-  // Slice starting from the Nth-from-last compact boundary (inclusive)
-  const sliceFromIdx =
-    compactIndices[compactIndices.length - tailCompactions] ?? 0;
-  const slicedMessages = workingMessages.slice(sliceFromIdx);
-  const firstId = slicedMessages[0]
-    ? getMessageId(slicedMessages[0])
-    : undefined;
-
   return {
     messages: slicedMessages,
     pagination: {
-      hasOlderMessages: true,
+      hasOlderMessages,
       totalMessageCount,
       returnedMessageCount: slicedMessages.length,
       truncatedBeforeMessageId: firstId,

--- a/packages/server/test/sessions/pagination.test.ts
+++ b/packages/server/test/sessions/pagination.test.ts
@@ -281,4 +281,68 @@ describe("sliceAtCompactBoundaries", () => {
     expect(result.pagination.totalCompactions).toBe(2);
     expect(result.pagination.hasOlderMessages).toBe(true);
   });
+
+  it("caps the returned tail when maxMessages is smaller than the sliced window", () => {
+    const messages = [
+      msg("user", "u1"),
+      compactBoundary("cb1"),
+      msg("assistant", "a1"),
+      compactBoundary("cb2"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+      msg("user", "u3"),
+      msg("assistant", "a3"),
+    ];
+
+    const result = sliceAtCompactBoundaries(messages, 1, undefined, 3);
+
+    expect(result.messages.map((m) => m.uuid)).toEqual(["a2", "u3", "a3"]);
+    expect(result.pagination).toEqual({
+      hasOlderMessages: true,
+      totalMessageCount: 8,
+      returnedMessageCount: 3,
+      truncatedBeforeMessageId: "a2",
+      totalCompactions: 2,
+    } satisfies PaginationInfo);
+  });
+
+  it("supports progressive loading when maxMessages trims the tail chunk", () => {
+    const messages = [
+      msg("user", "u1"),
+      compactBoundary("cb1"),
+      msg("assistant", "a1"),
+      compactBoundary("cb2"),
+      msg("user", "u2"),
+      msg("assistant", "a2"),
+      msg("user", "u3"),
+      msg("assistant", "a3"),
+    ];
+
+    const first = sliceAtCompactBoundaries(messages, 1, undefined, 3);
+    expect(first.messages.map((m) => m.uuid)).toEqual(["a2", "u3", "a3"]);
+
+    const second = sliceAtCompactBoundaries(
+      messages,
+      1,
+      first.pagination.truncatedBeforeMessageId,
+      3,
+    );
+
+    expect(second.messages.map((m) => m.uuid)).toEqual(["cb2", "u2"]);
+    expect(second.pagination.hasOlderMessages).toBe(true);
+    expect(second.pagination.truncatedBeforeMessageId).toBe("cb2");
+
+    const third = sliceAtCompactBoundaries(
+      messages,
+      1,
+      second.pagination.truncatedBeforeMessageId,
+      3,
+    );
+
+    expect(third.messages.map((m) => m.uuid)).toEqual(["u1", "cb1", "a1"]);
+    expect(third.pagination.hasOlderMessages).toBe(false);
+
+    const allLoaded = [...third.messages, ...second.messages, ...first.messages];
+    expect(allLoaded.map((m) => m.uuid)).toEqual(messages.map((m) => m.uuid));
+  });
 });


### PR DESCRIPTION
## What changed
- disabled global inbox fetching outside the projects and inbox routes
- changed the agents badge to use the lighter processes endpoint instead of the inbox endpoint
- delayed and consolidated sidebar session loading so the page-critical requests finish first
- loaded terminated agent rows after the active agents list instead of blocking the first paint

## Why
Entering Agents, returning to a conversation, and opening sessions were all paying for extra global requests on first paint. The main avoidable costs were a global inbox fetch on pages that did not need inbox data and duplicate sidebar session fetches.

## Impact
- /agents no longer triggers /api/inbox on first load
- session pages no longer trigger /api/inbox on first load
- sidebar session requests are reduced and deferred slightly so the main page can render sooner
- active agent state still updates, but with a lighter request path

## Root cause
The app mounted InboxProvider globally and multiple sidebar hooks fetched global session data independently. That created redundant cross-project aggregation work during navigation.

## Validation
- targeted TypeScript diagnostics for the touched client files passed
- pnpm typecheck completed in the repo environment
- live verification on http://127.0.0.1:3400
  - /api/processes?includeTerminated=true returned in about 465ms
  - /api/inbox returned in about 2864ms
  - browser verification confirmed /agents and session pages no longer issue /api/inbox on first load
