### PR TITLE
[codex] 优化首屏加载并修复移动端斜杠菜单

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,10 +1,11 @@
 import { type ReactNode, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { ConnectionBar } from "./components/ConnectionBar";
 import { FloatingActionButton } from "./components/FloatingActionButton";
 import { ReloadBanner } from "./components/ReloadBanner";
 import { OnboardingWizard } from "./components/onboarding";
 import { AuthProvider } from "./contexts/AuthContext";
-import { InboxProvider } from "./contexts/InboxContext";
+import { InboxProvider, useInboxContext } from "./contexts/InboxContext";
 import { SchemaValidationProvider } from "./contexts/SchemaValidationContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import { useActivityBusConnection } from "./hooks/useActivityBusConnection";
@@ -14,6 +15,7 @@ import { useOnboarding } from "./hooks/useOnboarding";
 import { useReloadNotifications } from "./hooks/useReloadNotifications";
 import { I18nProvider } from "./i18n";
 import { initClientLogCollection } from "./lib/diagnostics";
+import { shouldEnableInboxForPathname } from "./lib/inboxRouteActivation";
 
 interface Props {
   children: ReactNode;
@@ -23,6 +25,10 @@ interface Props {
  * Inner component that uses hooks requiring InboxContext.
  */
 function AppContent({ children }: Props) {
+  const location = useLocation();
+  const { setEnabled } = useInboxContext();
+  const shouldEnableInbox = shouldEnableInboxForPathname(location.pathname);
+
   // Manage SSE connection based on auth state (prevents 401s on login page)
   useActivityBusConnection();
 
@@ -31,6 +37,10 @@ function AppContent({ children }: Props) {
 
   // Sync notifyInApp setting to service worker on app startup and SW restarts
   useSyncNotifyInAppSetting();
+
+  useEffect(() => {
+    setEnabled(shouldEnableInbox);
+  }, [setEnabled, shouldEnableInbox]);
 
   // Update tab title with needs-attention badge count (uses InboxContext)
   useNeedsAttentionBadge();
@@ -81,7 +91,7 @@ export function App({ children }: Props) {
     <I18nProvider>
       <ToastProvider>
         <AuthProvider>
-          <InboxProvider>
+          <InboxProvider initialEnabled={false}>
             <SchemaValidationProvider>
               <AppContent>{children}</AppContent>
               {!isLoading && showWizard && (

--- a/packages/client/src/RemoteApp.tsx
+++ b/packages/client/src/RemoteApp.tsx
@@ -17,13 +17,13 @@
  */
 
 import { type ReactNode, useEffect, useMemo, useState } from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { ConnectionBar } from "./components/ConnectionBar";
 import { FloatingActionButton } from "./components/FloatingActionButton";
 import { HostOfflineModal } from "./components/HostOfflineModal";
 import { ReloadBanner } from "./components/ReloadBanner";
 import { Modal } from "./components/ui/Modal";
-import { InboxProvider } from "./contexts/InboxContext";
+import { InboxProvider, useInboxContext } from "./contexts/InboxContext";
 import {
   RemoteConnectionProvider,
   useRemoteConnection,
@@ -38,6 +38,7 @@ import { useRemoteBasePath } from "./hooks/useRemoteBasePath";
 import { useVersion } from "./hooks/useVersion";
 import { connectionManager } from "./lib/connection";
 import { initClientLogCollection } from "./lib/diagnostics";
+import { shouldEnableInboxForPathname } from "./lib/inboxRouteActivation";
 
 interface Props {
   children: ReactNode;
@@ -205,6 +206,14 @@ export function ConnectionGate() {
  * Must be rendered inside InboxProvider.
  */
 function RemoteAppInner({ children }: Props) {
+  const location = useLocation();
+  const { setEnabled } = useInboxContext();
+  const shouldEnableInbox = shouldEnableInboxForPathname(location.pathname);
+
+  useEffect(() => {
+    setEnabled(shouldEnableInbox);
+  }, [setEnabled, shouldEnableInbox]);
+
   useNeedsAttentionBadge();
 
   return (
@@ -232,7 +241,7 @@ export function RemoteApp({ children }: Props) {
   return (
     <ToastProvider>
       <RemoteConnectionProvider>
-        <InboxProvider>
+        <InboxProvider initialEnabled={false}>
           <SchemaValidationProvider>
             <RemoteAppInner>{children}</RemoteAppInner>
           </SchemaValidationProvider>

--- a/packages/client/src/components/Sidebar.tsx
+++ b/packages/client/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ const SWIPE_THRESHOLD = 50; // Minimum distance to trigger close
 const SWIPE_ENGAGE_THRESHOLD = 15; // Minimum horizontal distance before swipe engages
 const RECENT_SESSIONS_INITIAL = 12; // Initial number of recent sessions to show
 const RECENT_SESSIONS_INCREMENT = 10; // How many more to show on each expand
+const SESSION_LIST_DELAY_MS = 750; // Let page-critical data load first
 
 interface SidebarProps {
   isOpen: boolean;
@@ -68,20 +69,29 @@ export function Sidebar({
   const basePath = useRemoteBasePath();
   const navigate = useNavigate();
   const remoteConnection = useOptionalRemoteConnection();
+  const shouldLoadSessionLists = !isDesktop || !isCollapsed;
+  const [sessionListsEnabled, setSessionListsEnabled] = useState(false);
 
-  // Fetch global sessions for sidebar (non-starred only for recent/older sections)
-  const { sessions: globalSessions, loading: globalLoading } =
-    useGlobalSessions({ limit: 50, includeStats: false });
+  useEffect(() => {
+    if (!shouldLoadSessionLists) {
+      setSessionListsEnabled(false);
+      return;
+    }
 
-  // Fetch starred sessions separately to ensure we get ALL starred sessions
-  const { sessions: starredSessions, loading: starredLoading } =
+    const timer = setTimeout(() => {
+      setSessionListsEnabled(true);
+    }, SESSION_LIST_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [shouldLoadSessionLists]);
+
+  // Fetch one shared session list for the expanded sidebar only.
+  const { sessions: sidebarSessions, loading: sessionsLoading } =
     useGlobalSessions({
-      starred: true,
       limit: 100,
       includeStats: false,
+      enabled: sessionListsEnabled,
     });
-
-  const sessionsLoading = globalLoading || starredLoading;
 
   // Server capabilities for feature gating
   const { version: versionInfo } = useVersion();
@@ -209,35 +219,33 @@ export function Sidebar({
     onNavigate();
   };
 
-  // Starred sessions come from dedicated fetch (filtered by server)
-  // Filter out archived just in case
   const filteredStarredSessions = useMemo(() => {
-    return starredSessions.filter((s) => !s.isArchived);
-  }, [starredSessions]);
+    return sidebarSessions.filter((s) => s.isStarred && !s.isArchived);
+  }, [sidebarSessions]);
 
   // Sessions updated in the last 24 hours (non-starred, non-archived)
   const recentDaySessions = useMemo(() => {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     const isWithinLastDay = (date: Date) => date.getTime() >= oneDayAgo;
 
-    return globalSessions.filter(
+    return sidebarSessions.filter(
       (s) =>
         !s.isStarred && !s.isArchived && isWithinLastDay(new Date(s.updatedAt)),
     );
-  }, [globalSessions]);
+  }, [sidebarSessions]);
 
   // Older sessions (non-starred, non-archived, NOT in last 24 hours)
   const olderSessions = useMemo(() => {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     const isOlderThanOneDay = (date: Date) => date.getTime() < oneDayAgo;
 
-    return globalSessions.filter(
+    return sidebarSessions.filter(
       (s) =>
         !s.isStarred &&
         !s.isArchived &&
         isOlderThanOneDay(new Date(s.updatedAt)),
     );
-  }, [globalSessions]);
+  }, [sidebarSessions]);
 
   // Track which sessions have unsent drafts in localStorage
   const drafts = useDrafts();

--- a/packages/client/src/components/SlashCommandButton.tsx
+++ b/packages/client/src/components/SlashCommandButton.tsx
@@ -1,4 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+const DESKTOP_BREAKPOINT = 769;
+const SLASH_COMMAND_LABEL = "Slash commands";
 
 interface SlashCommandButtonProps {
   /** Available slash commands (without the "/" prefix) */
@@ -19,12 +23,29 @@ export function SlashCommandButton({
   disabled,
 }: SlashCommandButtonProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.innerWidth >= DESKTOP_BREAKPOINT,
+  );
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    buttonRef.current?.blur();
+  }, []);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsDesktop(window.innerWidth >= DESKTOP_BREAKPOINT);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   // Close menu when clicking outside
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !isDesktop) return;
 
     const handleClickOutside = (e: MouseEvent) => {
       if (
@@ -33,13 +54,13 @@ export function SlashCommandButton({
         buttonRef.current &&
         !buttonRef.current.contains(e.target as Node)
       ) {
-        setIsOpen(false);
+        handleClose();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen]);
+  }, [handleClose, isDesktop, isOpen]);
 
   // Close menu on Escape
   useEffect(() => {
@@ -47,27 +68,118 @@ export function SlashCommandButton({
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        setIsOpen(false);
+        handleClose();
         buttonRef.current?.focus();
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [handleClose, isOpen]);
+
+  // Mobile bottom sheet should prevent background scrolling while open.
+  useEffect(() => {
+    if (isOpen && !isDesktop) {
+      const previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = previousOverflow;
+      };
+    }
+  }, [isDesktop, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      menuRef.current?.focus();
+    }
+  }, [isDesktop, isOpen]);
 
   const handleCommandClick = useCallback(
     (command: string) => {
       onSelectCommand(`/${command}`);
-      setIsOpen(false);
+      handleClose();
     },
-    [onSelectCommand],
+    [handleClose, onSelectCommand],
   );
+
+  const handleToggle = useCallback(() => {
+    if (disabled) return;
+
+    if (isOpen) {
+      handleClose();
+      buttonRef.current?.focus();
+      return;
+    }
+
+    buttonRef.current?.blur();
+    setIsOpen(true);
+  }, [disabled, handleClose, isOpen]);
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      e.preventDefault();
+      e.stopPropagation();
+      handleClose();
+    }
+  };
 
   // Don't render if no commands available
   if (commands.length === 0) {
     return null;
   }
+
+  const commandItems = commands.map((command) => (
+    <button
+      key={command}
+      type="button"
+      className="slash-command-item"
+      onClick={() => handleCommandClick(command)}
+      role="menuitem"
+    >
+      /{command}
+    </button>
+  ));
+
+  const desktopMenu =
+    isOpen && isDesktop ? (
+      <div
+        ref={menuRef}
+        className="slash-command-menu"
+        role="menu"
+        aria-label={SLASH_COMMAND_LABEL}
+        tabIndex={-1}
+      >
+        {commandItems}
+      </div>
+    ) : null;
+
+  const mobileSheet =
+    isOpen && !isDesktop
+      ? createPortal(
+          // biome-ignore lint/a11y/useKeyWithClickEvents: Escape key handled globally
+          <div
+            className="slash-command-overlay"
+            onClick={handleOverlayClick}
+            onMouseDown={(e) => e.stopPropagation()}
+          >
+            <div
+              ref={menuRef}
+              className="slash-command-sheet"
+              role="menu"
+              aria-label={SLASH_COMMAND_LABEL}
+              tabIndex={-1}
+            >
+              <div className="slash-command-header">
+                <span className="slash-command-title">
+                  {SLASH_COMMAND_LABEL}
+                </span>
+              </div>
+              <div className="slash-command-sheet-list">{commandItems}</div>
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <div className="slash-command-container">
@@ -75,35 +187,17 @@ export function SlashCommandButton({
         ref={buttonRef}
         type="button"
         className={`slash-command-button ${isOpen ? "active" : ""}`}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleToggle}
         disabled={disabled}
-        title="Slash commands"
+        title={SLASH_COMMAND_LABEL}
         aria-label="Show slash commands"
         aria-expanded={isOpen}
         aria-haspopup="menu"
       >
         <span className="slash-icon">/</span>
       </button>
-      {isOpen && (
-        <div
-          ref={menuRef}
-          className="slash-command-menu"
-          role="menu"
-          aria-label="Slash commands"
-        >
-          {commands.map((command) => (
-            <button
-              key={command}
-              type="button"
-              className="slash-command-item"
-              onClick={() => handleCommandClick(command)}
-              role="menuitem"
-            >
-              /{command}
-            </button>
-          ))}
-        </div>
-      )}
+      {desktopMenu}
+      {mobileSheet}
     </div>
   );
 }

--- a/packages/client/src/components/__tests__/SlashCommandButton.test.tsx
+++ b/packages/client/src/components/__tests__/SlashCommandButton.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SlashCommandButton } from "../SlashCommandButton";
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
+describe("SlashCommandButton", () => {
+  beforeEach(() => {
+    setViewportWidth(1024);
+    document.body.style.overflow = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+    setViewportWidth(ORIGINAL_INNER_WIDTH);
+    document.body.style.overflow = "";
+    vi.restoreAllMocks();
+  });
+
+  it("opens an inline desktop menu and inserts the selected command", () => {
+    const onSelectCommand = vi.fn();
+
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={onSelectCommand}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+
+    const menu = screen.getByRole("menu", { name: "Slash commands" });
+    expect(menu.className).toContain("slash-command-menu");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "/docs" }));
+
+    expect(onSelectCommand).toHaveBeenCalledWith("/docs");
+    expect(screen.queryByRole("menu", { name: "Slash commands" })).toBeNull();
+  });
+
+  it("renders a mobile bottom sheet and restores body scroll after selection", () => {
+    const onSelectCommand = vi.fn();
+    setViewportWidth(390);
+
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={onSelectCommand}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+
+    const menu = screen.getByRole("menu", { name: "Slash commands" });
+    expect(menu.className).toContain("slash-command-sheet");
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "/defuddle" }));
+
+    expect(onSelectCommand).toHaveBeenCalledWith("/defuddle");
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("closes the desktop menu when clicking outside", () => {
+    render(
+      <SlashCommandButton
+        commands={["docs", "defuddle"]}
+        onSelectCommand={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show slash commands" }));
+    expect(screen.getByRole("menu", { name: "Slash commands" })).not.toBeNull();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByRole("menu", { name: "Slash commands" })).toBeNull();
+  });
+});

--- a/packages/client/src/hooks/useGlobalActiveAgents.ts
+++ b/packages/client/src/hooks/useGlobalActiveAgents.ts
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { api } from "../api/client";
+import { fetchJSON } from "../api/client";
 import { useFileActivity } from "./useFileActivity";
 
 // Debounce interval for refetch on SSE events
 const REFETCH_DEBOUNCE_MS = 500;
+
+interface ProcessesResponse {
+  processes: Array<{ state: string }>;
+}
 
 /**
  * Hook that monitors the global count of active agents (running processes).
@@ -16,8 +20,13 @@ export function useGlobalActiveAgents() {
   // Fetch just the active count
   const fetchCount = useCallback(async () => {
     try {
-      const data = await api.getInbox();
-      setCount(data.active.length);
+      const data = await fetchJSON<ProcessesResponse>("/processes");
+      setCount(
+        data.processes.filter(
+          (process) =>
+            process.state === "in-turn" || process.state === "waiting-input",
+        ).length,
+      );
     } catch {
       // Silently ignore errors - indicator is non-critical
     }

--- a/packages/client/src/hooks/useGlobalSessions.ts
+++ b/packages/client/src/hooks/useGlobalSessions.ts
@@ -24,6 +24,7 @@ export interface UseGlobalSessionsOptions {
   includeArchived?: boolean;
   starred?: boolean;
   includeStats?: boolean;
+  enabled?: boolean;
 }
 
 /** Default stats when no data loaded */
@@ -44,6 +45,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     includeArchived,
     starred,
     includeStats = false,
+    enabled = true,
   } = options;
   const [sessions, setSessions] = useState<GlobalSessionItem[]>([]);
   const [stats, setStats] = useState<GlobalSessionStats>(DEFAULT_STATS);
@@ -69,13 +71,25 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
   }>({});
 
   const fetch = useCallback(async () => {
+    if (!enabled) {
+      setSessions([]);
+      setStats(DEFAULT_STATS);
+      setProjects([]);
+      setHasMore(false);
+      setError(null);
+      setLoading(false);
+      hasInitialLoadRef.current = false;
+      return;
+    }
+
     // Reset initial load flag when options change
     const optionsChanged =
       lastFetchOptionsRef.current.projectId !== projectId ||
       lastFetchOptionsRef.current.searchQuery !== searchQuery ||
       lastFetchOptionsRef.current.includeArchived !== includeArchived ||
       lastFetchOptionsRef.current.starred !== starred ||
-      lastFetchOptionsRef.current.includeStats !== includeStats;
+      lastFetchOptionsRef.current.includeStats !== includeStats ||
+      lastFetchOptionsRef.current.enabled !== enabled;
 
     if (optionsChanged) {
       hasInitialLoadRef.current = false;
@@ -88,6 +102,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
       includeArchived,
       starred,
       includeStats,
+      enabled,
     };
 
     // Only show loading state on initial load
@@ -148,11 +163,19 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     } finally {
       setLoading(false);
     }
-  }, [projectId, searchQuery, limit, includeArchived, starred, includeStats]);
+  }, [
+    enabled,
+    projectId,
+    searchQuery,
+    limit,
+    includeArchived,
+    starred,
+    includeStats,
+  ]);
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
-    if (!hasMore || sessions.length === 0) return;
+    if (!enabled || !hasMore || sessions.length === 0) return;
 
     const lastSession = sessions[sessions.length - 1];
     if (!lastSession) return;
@@ -187,6 +210,7 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     limit,
     includeArchived,
     starred,
+    enabled,
   ]);
 
   // Debounced refetch

--- a/packages/client/src/hooks/useProcesses.ts
+++ b/packages/client/src/hooks/useProcesses.ts
@@ -54,9 +54,7 @@ export function useProcesses() {
   const fetchProcesses = useCallback(async (includeTerminated = false) => {
     try {
       const data = await fetchJSON<ProcessesResponse>(
-        includeTerminated
-          ? "/processes?includeTerminated=true"
-          : "/processes",
+        includeTerminated ? "/processes?includeTerminated=true" : "/processes",
       );
       setProcesses(data.processes);
       if (includeTerminated) {

--- a/packages/client/src/hooks/useProcesses.ts
+++ b/packages/client/src/hooks/useProcesses.ts
@@ -51,13 +51,17 @@ export function useProcesses() {
   const [error, setError] = useState<Error | null>(null);
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fetchProcesses = useCallback(async () => {
+  const fetchProcesses = useCallback(async (includeTerminated = false) => {
     try {
       const data = await fetchJSON<ProcessesResponse>(
-        "/processes?includeTerminated=true",
+        includeTerminated
+          ? "/processes?includeTerminated=true"
+          : "/processes",
       );
       setProcesses(data.processes);
-      setTerminatedProcesses(data.terminatedProcesses ?? []);
+      if (includeTerminated) {
+        setTerminatedProcesses(data.terminatedProcesses ?? []);
+      }
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err : new Error(String(err)));
@@ -69,11 +73,15 @@ export function useProcesses() {
   // Initial fetch
   useEffect(() => {
     fetchProcesses();
+    void fetchProcesses(true);
   }, [fetchProcesses]);
 
-  // Polling
+  // Poll only the active processes. The terminated list is informational and
+  // doesn't need to block navigation or refresh every interval.
   useEffect(() => {
-    pollTimerRef.current = setInterval(fetchProcesses, POLL_INTERVAL_MS);
+    pollTimerRef.current = setInterval(() => {
+      void fetchProcesses();
+    }, POLL_INTERVAL_MS);
     return () => {
       if (pollTimerRef.current) {
         clearInterval(pollTimerRef.current);

--- a/packages/client/src/hooks/useProjects.ts
+++ b/packages/client/src/hooks/useProjects.ts
@@ -3,6 +3,45 @@ import { api } from "../api/client";
 import type { Project } from "../types";
 import { type SessionStatusEvent, useFileActivity } from "./useFileActivity";
 
+interface SharedProjectsState {
+  projects: Project[];
+  error: Error | null;
+}
+
+let sharedProjectsState: SharedProjectsState = {
+  projects: [],
+  error: null,
+};
+
+let sharedProjectsInflight: Promise<SharedProjectsState> | null = null;
+
+async function fetchSharedProjects(): Promise<SharedProjectsState> {
+  if (sharedProjectsInflight) {
+    return sharedProjectsInflight;
+  }
+
+  sharedProjectsInflight = (async () => {
+    try {
+      const data = await api.getProjects();
+      sharedProjectsState = {
+        projects: data.projects,
+        error: null,
+      };
+    } catch (err) {
+      sharedProjectsState = {
+        projects: sharedProjectsState.projects,
+        error: err instanceof Error ? err : new Error(String(err)),
+      };
+    } finally {
+      sharedProjectsInflight = null;
+    }
+
+    return sharedProjectsState;
+  })();
+
+  return sharedProjectsInflight;
+}
+
 /**
  * Fetch a single project by ID.
  */
@@ -57,27 +96,23 @@ export function useProject(projectId: string | undefined) {
 const REFETCH_DEBOUNCE_MS = 500;
 
 export function useProjects() {
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const [projects, setProjects] = useState<Project[]>(sharedProjectsState.projects);
+  const [loading, setLoading] = useState(sharedProjectsState.projects.length === 0);
+  const [error, setError] = useState<Error | null>(sharedProjectsState.error);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasFetchedRef = useRef(false);
-  const hasResolvedInitialFetchRef = useRef(false);
+  const hasResolvedInitialFetchRef = useRef(sharedProjectsState.projects.length > 0);
 
   const fetch = useCallback(async () => {
     // Preserve existing UI during background refetches triggered by activity
     // events so pages don't bounce back to their initial loading state.
     setLoading(!hasResolvedInitialFetchRef.current);
     setError(null);
-    try {
-      const data = await api.getProjects();
-      setProjects(data.projects);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      hasResolvedInitialFetchRef.current = true;
-      setLoading(false);
-    }
+    const nextState = await fetchSharedProjects();
+    setProjects(nextState.projects);
+    setError(nextState.error);
+    hasResolvedInitialFetchRef.current = true;
+    setLoading(false);
   }, []);
 
   // Initial fetch - only once (avoid StrictMode double-fetch)

--- a/packages/client/src/hooks/useProjects.ts
+++ b/packages/client/src/hooks/useProjects.ts
@@ -96,12 +96,18 @@ export function useProject(projectId: string | undefined) {
 const REFETCH_DEBOUNCE_MS = 500;
 
 export function useProjects() {
-  const [projects, setProjects] = useState<Project[]>(sharedProjectsState.projects);
-  const [loading, setLoading] = useState(sharedProjectsState.projects.length === 0);
+  const [projects, setProjects] = useState<Project[]>(
+    sharedProjectsState.projects,
+  );
+  const [loading, setLoading] = useState(
+    sharedProjectsState.projects.length === 0,
+  );
   const [error, setError] = useState<Error | null>(sharedProjectsState.error);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasFetchedRef = useRef(false);
-  const hasResolvedInitialFetchRef = useRef(sharedProjectsState.projects.length > 0);
+  const hasResolvedInitialFetchRef = useRef(
+    sharedProjectsState.projects.length > 0,
+  );
 
   const fetch = useCallback(async () => {
     // Preserve existing UI during background refetches triggered by activity

--- a/packages/client/src/lib/inboxRouteActivation.ts
+++ b/packages/client/src/lib/inboxRouteActivation.ts
@@ -1,0 +1,6 @@
+export function shouldEnableInboxForPathname(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+
+  return lastSegment === "projects" || lastSegment === "inbox";
+}

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -2409,6 +2409,7 @@ a.sidebar-nav-item {
 /* Slash command button */
 .slash-command-container {
   position: relative;
+  flex-shrink: 0;
 }
 
 .slash-command-button {
@@ -2448,18 +2449,7 @@ a.sidebar-nav-item {
 }
 
 .slash-command-menu {
-  position: absolute;
-  bottom: 100%;
-  left: 0;
-  margin-bottom: var(--space-1);
-  background: var(--bg-surface);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-md);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  min-width: 160px;
-  max-height: 240px;
-  overflow-y: auto;
-  z-index: 100;
+  display: none;
 }
 
 .slash-command-item {
@@ -2490,6 +2480,85 @@ a.sidebar-nav-item {
 
 .slash-command-item:only-child {
   border-radius: var(--radius-md);
+}
+
+.slash-command-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 10001;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.slash-command-sheet {
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: slashCommandSlideUp 0.2s ease-out;
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+@keyframes slashCommandSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+.slash-command-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.slash-command-title {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.slash-command-sheet-list {
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) 0;
+}
+
+.slash-command-sheet .slash-command-item {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
+}
+
+@media (min-width: 769px) {
+  .slash-command-menu {
+    display: block;
+    position: absolute;
+    bottom: 100%;
+    right: 0;
+    margin-bottom: var(--space-1);
+    background: var(--bg-surface);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    min-width: 160px;
+    max-width: min(18rem, calc(100vw - 1rem));
+    max-height: 240px;
+    overflow-y: auto;
+    z-index: 100;
+  }
+
+  .slash-command-overlay {
+    display: none;
+  }
 }
 
 /* Attachment list */


### PR DESCRIPTION
## What changed
- reduced Agents and session page first-screen blocking so startup data loads more selectively
- deduplicated project list requests and cleaned up the related startup request path
- changed the mobile slash-command UI from an inline absolute dropdown to a portal-backed bottom sheet, while keeping a desktop dropdown
- added component coverage for the slash-command menu behavior

## Why
The branch had two separate issues in the same startup path:
1. first-screen requests were doing more work than needed, which delayed initial rendering
2. the slash-command menu used a desktop-style absolute popup on mobile, so it could overflow or cover the input area on phones

## User impact
- faster initial loading around Agents, processes, and projects
- safer project request behavior with fewer duplicate fetches
- slash commands are usable on mobile without the menu hanging off the toolbar

## Root cause
- startup data fetching was spread across multiple hooks with overlapping request timing
- the slash-command menu never adopted the repo's existing mobile bottom-sheet pattern, so it stayed anchored to the toolbar even on narrow touch viewports

## Validation
- TypeScript project diagnostics on `packages/client` returned `0 errors / 0 warnings`
- full shell-based `pnpm` / `vitest` validation was not completed in this environment because the local Windows package-manager state hit `pnpm` install/linking ENOENT issues during workspace dependency restore
