### PR TITLE
feat(client): configurable base path for self-hosted remote SPA + docs

### DIFF
--- a/docs/project/remote-access.md
+++ b/docs/project/remote-access.md
@@ -20,7 +20,7 @@ yepanywhere --setup-remote-access --username myserver --password "secretpass123"
 - Your yepanywhere server connects to our public relay
 - Your phone connects to the same relay and authenticates with SRP-6a (zero-knowledge password proof)
 - All traffic is end-to-end encrypted with TweetNaCl — the relay only sees opaque blobs
-- You can [run your own relay](relay-design.md) if you prefer
+- You can [run your own relay](self-hosted-relay.md) if you prefer (full end-to-end self-hosted setup)
 
 **Security:**
 - The relay never sees your password or session keys

--- a/docs/project/self-hosted-relay.md
+++ b/docs/project/self-hosted-relay.md
@@ -1,0 +1,183 @@
+# Self-Hosted Relay
+
+Run the relay and the remote client entirely on your own VPS — no dependency on `yepanywhere.com`. Good fit if you already have a server with a domain name and prefer to control the full stack.
+
+For context on the relay architecture, see [relay-design.md](relay-design.md).
+
+## What You'll Run
+
+| Component | Where | Role |
+|-----------|-------|------|
+| `packages/relay` | Your VPS (systemd) | WebSocket pipe between phone and local machine |
+| `packages/client` (`dist-remote/`) | Your VPS (static files behind nginx) | Remote client SPA, served at `/remote/` |
+| nginx | Your VPS | TLS termination + WebSocket proxy to relay |
+| `yepanywhere` | Your local dev machine | Registers with *your* relay instead of `yepanywhere.com` |
+
+## Prerequisites
+
+- VPS with a public IP and a domain (e.g. `yep.example.com`)
+- Node.js 20+, `pnpm`, `nginx`, `certbot`
+- DNS A record pointing `yep.example.com` to the VPS
+
+## 1. Build Relay + Remote Client on the VPS
+
+```bash
+git clone --depth 1 https://github.com/kzahel/yepanywhere.git /opt/yepanywhere
+cd /opt/yepanywhere
+pnpm install
+pnpm --filter shared build
+pnpm --filter relay build
+
+# IMPORTANT: set VITE_BASE to the path where the SPA will be served.
+# This emits HTML that references /remote/assets/* (matching where files
+# actually live on disk). Without it, the HTML references /assets/* and
+# you have to paper over the mismatch with nginx aliases.
+VITE_BASE=/remote/ pnpm --filter client build:remote
+```
+
+Deploy the built remote client:
+
+```bash
+mkdir -p /var/www/yep-remote/remote
+cp -r packages/client/dist-remote/* /var/www/yep-remote/remote/
+cp packages/client/public/{favicon.ico,icon-192.png,icon-512.png,manifest.json,sw.js} \
+   /var/www/yep-remote/remote/
+```
+
+The built entry point is `remote.html`. The SPA fallback in nginx (below) references it directly — no rename needed.
+
+## 2. Relay as a systemd Service
+
+`/etc/systemd/system/yep-relay.service`:
+
+```ini
+[Unit]
+Description=Yep Anywhere Relay
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/yepanywhere/packages/relay
+ExecStart=/usr/bin/node dist/index.js
+Environment=NODE_ENV=production
+Environment=RELAY_PORT=4400
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload
+systemctl enable --now yep-relay
+journalctl -u yep-relay -f   # tail logs
+```
+
+## 3. nginx Config
+
+`/etc/nginx/sites-available/yep-anywhere`:
+
+```nginx
+server {
+    server_name yep.example.com;
+    root /var/www/yep-remote;
+
+    # Relay WebSocket
+    location /relay/ {
+        proxy_pass http://127.0.0.1:4400/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+        proxy_send_timeout 86400;
+    }
+
+    # Remote client SPA (static files + SPA fallback)
+    location /remote/ {
+        try_files $uri /remote/remote.html;
+    }
+
+    # Redirect bare / to /remote/
+    location = / {
+        return 302 /remote/;
+    }
+
+    listen 80;
+}
+```
+
+Enable + provision TLS:
+
+```bash
+ln -s /etc/nginx/sites-available/yep-anywhere /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+certbot --nginx -d yep.example.com
+```
+
+> If you built **without** `VITE_BASE=/remote/`, the emitted HTML references `/assets/...` and `/favicon.ico` at the server root. You'll need extra nginx `alias` rules to map those to `/var/www/yep-remote/remote/assets/` and friends. Rebuilding with `VITE_BASE=/remote/` is simpler.
+
+## 4. Local Machine
+
+Point your local `yepanywhere` at your own relay:
+
+```bash
+npm i -g yepanywhere
+yepanywhere --setup-remote-access \
+  --username myserver \
+  --password "yoursecret" \
+  --relay "wss://yep.example.com/relay/ws"
+
+# Start (from a clean terminal — see note below)
+yepanywhere
+```
+
+> **`CLAUDECODE` env var**: if you launch `yepanywhere` from inside a Claude Code session, the `CLAUDECODE=1` env var inherited by spawned Claude subprocesses causes them to exit immediately. Launch from a fresh terminal, or prefix: `CLAUDECODE= yepanywhere`.
+
+## 5. Phone
+
+Open `https://yep.example.com/` → redirects to `/remote/`.
+On the login screen → **Show Advanced Options** → set **Custom Relay URL** to `wss://yep.example.com/relay/ws` → enter username + password.
+
+## Updating
+
+When upgrading the relay or remote client:
+
+```bash
+cd /opt/yepanywhere && git pull
+pnpm install
+pnpm --filter shared build
+pnpm --filter relay build
+VITE_BASE=/remote/ pnpm --filter client build:remote
+
+rm -rf /var/www/yep-remote/remote
+mkdir -p /var/www/yep-remote/remote
+cp -r packages/client/dist-remote/* /var/www/yep-remote/remote/
+cp packages/client/public/{favicon.ico,icon-192.png,icon-512.png,manifest.json,sw.js} \
+   /var/www/yep-remote/remote/
+
+systemctl restart yep-relay
+```
+
+**Restart your local `yepanywhere` too** after updating the npm package — a running process won't pick up changes to its own package or to `@anthropic-ai/claude-code` that were installed underneath it.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Grey screen at `/remote/`, 404s for `/assets/*.js` in browser console | Built without `VITE_BASE=/remote/` | Rebuild: `VITE_BASE=/remote/ pnpm --filter client build:remote` |
+| `/remote/` returns 404 | nginx `try_files` points at a filename that doesn't exist on disk | Ensure the fallback matches the actual file in `dist-remote/` (default: `remote.html`) |
+| `"Claude Code process exited with code 1"` in local `yepanywhere` output | `CLAUDECODE` env var is set in the parent shell | Launch from a clean terminal or use `CLAUDECODE= yepanywhere` |
+| Phone stuck on "Sending..." after updating `claude-code` or `yepanywhere` | Running process is older than the installed packages | Kill and restart `yepanywhere` — running version is visible in relay log `appVersion` on pair events |
+| `unknown_username` in relay log | Phone entered wrong username | Re-enter username used during `--setup-remote-access` (case-sensitive) |
+| Relay OK but phone can't reach it | Wrong relay URL on phone | Use `wss://yep.example.com/relay/ws` in Advanced Options |
+
+## Security
+
+- **SRP-6a**: username/password never leave the local side in plaintext; the relay stores only the verifier.
+- **NaCl XSalsa20-Poly1305**: all session traffic is end-to-end encrypted; the relay forwards opaque ciphertext.
+- TLS via Let's Encrypt protects the transport to/from the relay.

--- a/packages/client/vite.config.remote.ts
+++ b/packages/client/vite.config.remote.ts
@@ -32,6 +32,12 @@ const remoteDevPort = process.env.REMOTE_PORT
 // In watch mode (staging), don't empty the output dir to avoid race conditions
 const isWatchMode = process.argv.includes("--watch");
 
+// Base path for built assets. Defaults to "/" (for deployment at the server root,
+// e.g. GitHub Pages). Self-hosters who serve the remote SPA under a sub-path
+// (e.g. https://example.com/remote/) should build with VITE_BASE=/remote/ so the
+// emitted HTML references /remote/assets/* instead of /assets/*. See issue #27.
+const basePath = process.env.VITE_BASE || "/";
+
 /**
  * Plugin to serve remote.html instead of index.html in dev mode.
  * This makes the dev server behave like the production build.
@@ -64,6 +70,7 @@ function serveRemoteHtml(): Plugin {
 
 export default defineConfig({
   clearScreen: false,
+  base: basePath,
   plugins: [serveRemoteHtml(), react(), cspPlugin({ isRemote: true })],
   resolve: {
     conditions: ["source"],


### PR DESCRIPTION
## Summary

Addresses the long-standing self-hosting gap discussed in #27.

**Code** (one-line effective change + documentation):
- `packages/client/vite.config.remote.ts` now reads `base` from a `VITE_BASE` env var, defaulting to `/`. The default preserves current behavior for GitHub Pages / `yepanywhere.com`. Self-hosters who serve the remote SPA under `/remote/` can build with `VITE_BASE=/remote/` and the emitted HTML will reference `/remote/assets/*` directly — no nginx `alias` workarounds needed.

**Docs**:
- New `docs/project/self-hosted-relay.md` walks through an end-to-end self-hosted relay + remote client deployment: build, systemd, nginx, TLS, local setup, phone pairing. Includes a troubleshooting table for the pitfalls real self-hosters (including me) have hit.
- `docs/project/remote-access.md` retargets the "run your own relay" link from the architecture doc (`relay-design.md`) to the new how-to — one is design, the other is the step-by-step.

## Context

Issue #27 asked for a self-hosting guide for the relay + remote client. The client-side piece had a real rough edge: the router basename is hardcoded to `/remote` but the Vite build emits asset paths rooted at `/`, so serving the SPA at `/remote/` results in 404s on every asset unless operators add nginx aliases to paper over the mismatch. Making `base` configurable eliminates the need for those workarounds.

I'm running this exact setup in production (relay + static SPA on a Hetzner VPS behind nginx) — the new doc reflects that working configuration, genericized.

## Testing

- `VITE_BASE=/remote/ pnpm --filter client build:remote` — verified emitted `remote.html` references `/remote/assets/*`.
- Default build (no env var) — verified `base` falls through to `/` and current GH Pages-style output is unchanged.
- End-to-end: relay + SPA deployed per the new doc, phone pair + message flow working.

## No breaking changes

Default value of `base` is `"/"` — any existing deployment that doesn't set `VITE_BASE` builds identically to before this PR.

Refs #27.