### PR TITLE
Fixes incorrect Codex session titles

### DIFF
--- a/packages/server/src/indexes/SessionIndexService.ts
+++ b/packages/server/src/indexes/SessionIndexService.ts
@@ -48,12 +48,12 @@ export interface CachedSessionSummary {
 }
 
 export interface SessionIndexState {
-  version: 1;
+  version: 2;
   projectId: string;
   sessions: Record<string, CachedSessionSummary>;
 }
 
-const CURRENT_VERSION = 1;
+const CURRENT_VERSION = 2;
 
 export interface SessionIndexServiceOptions {
   /** Directory to store index files (defaults to ~/.yep-anywhere/indexes) */

--- a/packages/server/src/sessions/codex-reader.ts
+++ b/packages/server/src/sessions/codex-reader.ts
@@ -28,6 +28,7 @@ import {
   type UrlProjectId,
   getModelContextWindow,
   parseCodexSessionEntry,
+  stripIdeMetadata,
 } from "@yep-anywhere/shared";
 import { canonicalizeProjectPath } from "../projects/paths.js";
 import type {
@@ -445,10 +446,11 @@ export class CodexSessionReader implements ISessionReader {
         entry.type === "event_msg" &&
         entry.payload.type === "user_message"
       ) {
-        const fullTitle = entry.payload.message.trim();
+        const fullTitle = this.sanitizeTitleText(entry.payload.message);
         if (
-          skipLeadingSystemPrompts &&
-          this.isSystemPromptUserMessage(fullTitle)
+          !fullTitle ||
+          (skipLeadingSystemPrompts &&
+            this.isSystemPromptUserMessage(fullTitle))
         ) {
           continue;
         }
@@ -462,10 +464,9 @@ export class CodexSessionReader implements ISessionReader {
       if (entry.type === "response_item") {
         const payload = entry.payload;
         if (payload.type === "message" && payload.role === "user") {
-          const text = payload.content
-            .map((c) => ("text" in c ? c.text : ""))
-            .join("\n")
-            .trim();
+          const text = this.sanitizeTitleText(
+            payload.content.map((c) => ("text" in c ? c.text : "")).join("\n"),
+          );
           if (
             text &&
             !(skipLeadingSystemPrompts && this.isSystemPromptUserMessage(text))
@@ -489,6 +490,10 @@ export class CodexSessionReader implements ISessionReader {
       trimmed.startsWith("# AGENTS.md instructions") ||
       trimmed.startsWith("<environment_context>")
     );
+  }
+
+  private sanitizeTitleText(text: string): string {
+    return stripIdeMetadata(text).trim();
   }
 
   /**

--- a/packages/server/src/supervisor/Supervisor.ts
+++ b/packages/server/src/supervisor/Supervisor.ts
@@ -6,6 +6,7 @@ import {
   SESSION_TITLE_MAX_LENGTH,
   type ThinkingConfig,
   type UrlProjectId,
+  stripIdeMetadata,
 } from "@yep-anywhere/shared";
 import type { AgentActivity, PendingInputType } from "@yep-anywhere/shared";
 import { getLogger } from "../logging/logger.js";
@@ -1447,7 +1448,9 @@ export class Supervisor {
     );
     const firstContent = firstUser?.message?.content;
     const fullTitle =
-      typeof firstContent === "string" ? firstContent.trim() : "";
+      typeof firstContent === "string"
+        ? stripIdeMetadata(firstContent).trim()
+        : "";
     if (!fullTitle) {
       return { title: null, fullTitle: null, messageCount: 0 };
     }

--- a/packages/server/test/sessions/codex-reader-oss.test.ts
+++ b/packages/server/test/sessions/codex-reader-oss.test.ts
@@ -322,6 +322,103 @@ describe("CodexSessionReader - OSS Support", () => {
     expect(summary?.messageCount).toBe(1);
   });
 
+  it("strips VSCode IDE setup preambles from event_msg titles", async () => {
+    const sessionId = "ide-preamble-event-msg";
+    const now = new Date().toISOString();
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: now,
+        payload: {
+          id: sessionId,
+          cwd: "/test/project",
+          timestamp: now,
+          model_provider: "openai",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: `# Context from my IDE setup:
+
+## Active file: /tmp/foo.ts
+
+## Open tabs:
+- foo.ts: /tmp/foo.ts
+- bar.ts: /tmp/bar.ts
+
+## My request for Codex:
+Please explain this function`,
+        },
+      }),
+    ];
+
+    await writeFile(
+      join(testDir, `${sessionId}.jsonl`),
+      `${lines.join("\n")}\n`,
+    );
+
+    const summary = await reader.getSessionSummary(
+      sessionId,
+      "test-project" as UrlProjectId,
+    );
+    expect(summary?.title).toBe("Please explain this function");
+    expect(summary?.fullTitle).toBe("Please explain this function");
+  });
+
+  it("strips VSCode IDE setup preambles from response_item titles", async () => {
+    const sessionId = "ide-preamble-response-item";
+    const now = new Date().toISOString();
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: now,
+        payload: {
+          id: sessionId,
+          cwd: "/test/project",
+          timestamp: now,
+          model_provider: "openai",
+        },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        timestamp: now,
+        payload: {
+          type: "message",
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: `# Context from my IDE setup:
+
+## Active file: /tmp/foo.ts
+
+## Open tabs:
+- foo.ts: /tmp/foo.ts
+
+## My request for Codex:
+Summarize the bug`,
+            },
+          ],
+        },
+      }),
+    ];
+
+    await writeFile(
+      join(testDir, `${sessionId}.jsonl`),
+      `${lines.join("\n")}\n`,
+    );
+
+    const summary = await reader.getSessionSummary(
+      sessionId,
+      "test-project" as UrlProjectId,
+    );
+    expect(summary?.title).toBe("Summarize the bug");
+    expect(summary?.fullTitle).toBe("Summarize the bug");
+  });
+
   it("preserves originator from session metadata", async () => {
     const sessionId = "originator-passthrough";
     await createSessionFile(sessionId, "openai", "gpt-4o", "yep-anywhere");

--- a/packages/server/test/supervisor.test.ts
+++ b/packages/server/test/supervisor.test.ts
@@ -424,6 +424,59 @@ describe("Supervisor", () => {
       expect(created?.session.messageCount).toBe(1);
     });
 
+    it("strips IDE setup preambles from optimistic session titles", async () => {
+      const eventBus = new EventBus();
+      const events: BusEvent[] = [];
+      eventBus.subscribe((event) => events.push(event));
+
+      const realSdk: RealClaudeSDKInterface = {
+        startSession: async () => {
+          async function* iterator() {
+            yield {
+              type: "system",
+              subtype: "init",
+              session_id: "real-session-ide-1",
+            };
+            yield { type: "result", session_id: "real-session-ide-1" };
+          }
+          return {
+            iterator: iterator(),
+            queue: new MessageQueue(),
+            abort: () => {},
+          };
+        },
+      };
+
+      const supervisorWithBus = new Supervisor({
+        realSdk,
+        idleTimeoutMs: 100,
+        eventBus,
+      });
+
+      await supervisorWithBus.startSession("/tmp/test", {
+        text: `# Context from my IDE setup:
+
+## Active file: /tmp/foo.ts
+
+## Open tabs:
+- foo.ts: /tmp/foo.ts
+
+## My request for Codex:
+Investigate the bad session title`,
+      });
+
+      const created = events.find(
+        (e): e is Extract<BusEvent, { type: "session-created" }> =>
+          e.type === "session-created",
+      );
+      expect(created).toBeDefined();
+      expect(created?.session.title).toBe("Investigate the bad session title");
+      expect(created?.session.fullTitle).toBe(
+        "Investigate the bad session title",
+      );
+      expect(created?.session.messageCount).toBe(1);
+    });
+
     it("emits timed session-updated reconciliation from onSessionSummary", async () => {
       vi.useFakeTimers();
       try {

--- a/packages/shared/src/ideMetadata.ts
+++ b/packages/shared/src/ideMetadata.ts
@@ -12,6 +12,12 @@ const IDE_TAG_PATTERN = /<ide_(opened_file|selection)>[\s\S]*?<\/ide_\1>/g;
 const OPENED_FILE_TAG_PATTERN =
   /<ide_opened_file>([\s\S]*?)<\/ide_opened_file>/g;
 
+/** VSCode/Codex IDE context preamble injected ahead of the real prompt */
+const IDE_SETUP_PREAMBLE_HEADER = "# Context from my IDE setup:";
+
+/** Marks the beginning of the actual user request after IDE setup metadata */
+const IDE_REQUEST_HEADER_PATTERN = /^## My request for .+?:\s*$/m;
+
 /**
  * Check if text block is purely IDE metadata (for skipping in title extraction).
  * Returns true if the trimmed text starts with an IDE metadata tag.
@@ -19,6 +25,7 @@ const OPENED_FILE_TAG_PATTERN =
 export function isIdeMetadata(text: string): boolean {
   const trimmed = text.trim();
   return (
+    trimmed.startsWith(IDE_SETUP_PREAMBLE_HEADER) ||
     trimmed.startsWith("<ide_opened_file>") ||
     trimmed.startsWith("<ide_selection>")
   );
@@ -29,7 +36,22 @@ export function isIdeMetadata(text: string): boolean {
  * Returns the text with all <ide_opened_file> and <ide_selection> tags removed.
  */
 export function stripIdeMetadata(text: string): string {
-  return text.replace(IDE_TAG_PATTERN, "").trim();
+  const withoutTags = text.replace(IDE_TAG_PATTERN, "").trim();
+  return stripIdeSetupPreamble(withoutTags);
+}
+
+function stripIdeSetupPreamble(text: string): string {
+  if (!text.startsWith(IDE_SETUP_PREAMBLE_HEADER)) {
+    return text.trim();
+  }
+
+  const requestHeaderMatch = text.match(IDE_REQUEST_HEADER_PATTERN);
+  if (!requestHeaderMatch || requestHeaderMatch.index === undefined) {
+    return "";
+  }
+
+  const requestStart = requestHeaderMatch.index + requestHeaderMatch[0].length;
+  return text.slice(requestStart).trim();
 }
 
 /**

--- a/packages/shared/test/ideMetadata.test.ts
+++ b/packages/shared/test/ideMetadata.test.ts
@@ -33,6 +33,14 @@ describe("ideMetadata", () => {
       ).toBe(true);
     });
 
+    it("detects VSCode IDE setup preambles", () => {
+      expect(
+        isIdeMetadata(
+          "# Context from my IDE setup:\n\n## Active file: /tmp/foo.ts\n\n## My request for Codex:\nExplain this",
+        ),
+      ).toBe(true);
+    });
+
     it("returns false for regular text", () => {
       expect(isIdeMetadata("Hello, how can I help you?")).toBe(false);
     });
@@ -97,6 +105,30 @@ function foo() {
       expect(stripIdeMetadata("<ide_opened_file>file</ide_opened_file>")).toBe(
         "",
       );
+    });
+
+    it("strips VSCode IDE setup preambles and keeps the actual request", () => {
+      const input = `# Context from my IDE setup:
+
+## Active file: /tmp/foo.ts
+
+## Open tabs:
+- foo.ts: /tmp/foo.ts
+- bar.ts: /tmp/bar.ts
+
+## My request for Codex:
+What does this function do?`;
+      expect(stripIdeMetadata(input)).toBe("What does this function do?");
+    });
+
+    it("returns empty string when IDE setup preamble has no request body", () => {
+      const input = `# Context from my IDE setup:
+
+## Active file: /tmp/foo.ts
+
+## Open tabs:
+- foo.ts: /tmp/foo.ts`;
+      expect(stripIdeMetadata(input)).toBe("");
     });
   });
 


### PR DESCRIPTION
Fixes incorrect Codex session titles in yepanywhere when VSCode/IDE context is prepended to the first user message. Titles now strip `# Context from my IDE setup:` style preambles before generating session summaries, so lists and session headers show the actual request instead of IDE metadata or raw prompt noise.

Changes included:
- Extend shared IDE metadata sanitization to support VSCode/Codex IDE setup preambles
- Apply sanitized title extraction in the Codex reader for both `event_msg` and `response_item` user messages
- Apply the same sanitization to optimistic session titles in `Supervisor`
- Bump the session index version so cached stale titles are refreshed
- Add regression coverage for shared sanitization, Codex reader title extraction, and optimistic title generation

Validation:
`npx pnpm typecheck`
`npx pnpm test -- test/ideMetadata.test.ts in packages/shared`
`npx pnpm test -- test/sessions/codex-reader-oss.test.ts test/supervisor.test.ts in packages/server`

The next logical follow-up would be documenting that yepanywhere still derives Codex titles from local session transcripts today; matching the summarized titles shown in the Codex plugin would require a later integration with Codex Desktop/app-server thread metadata.