### PR TITLE
[codex] Optimize remote session loading

### DIFF
--- a/packages/client/src/hooks/__tests__/sessionViewCache.test.ts
+++ b/packages/client/src/hooks/__tests__/sessionViewCache.test.ts
@@ -1,0 +1,578 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  GlobalSessionItem,
+  GlobalSessionStats,
+  ProjectOption,
+} from "../../api/client";
+import type { Message, Session } from "../../types";
+import {
+  clearSessionViewCaches,
+  getCachedSessionDetail,
+  prioritizeSessionDetailLoad,
+  scheduleRecentSessionPrefetch,
+  setCachedGlobalSessions,
+  setCachedSessionDetail,
+} from "../sessionViewCache";
+import { useGlobalSessions } from "../useGlobalSessions";
+import { useSessionMessages } from "../useSessionMessages";
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    getSession: vi.fn(),
+    getSessionMetadata: vi.fn(),
+    getGlobalSessions: vi.fn(),
+    getGlobalSessionStats: vi.fn(),
+  },
+}));
+
+vi.mock("../../api/client", () => ({
+  api: mockApi,
+}));
+
+vi.mock("../../providers/registry", () => ({
+  getProvider: () => ({
+    capabilities: {
+      supportsDag: false,
+    },
+  }),
+}));
+
+vi.mock("../useFileActivity", () => ({
+  useFileActivity: vi.fn(),
+}));
+
+function makeMessage(id: string, content: string): Message {
+  return {
+    id,
+    type: "assistant",
+    role: "assistant",
+    content,
+    timestamp: `2026-05-11T00:00:0${id.length}.000Z`,
+  } as Message;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "session-1",
+    projectId: "project-1",
+    title: "Cached session",
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T00:00:01.000Z",
+    messageCount: 1,
+    provider: "claude",
+    ownership: { owner: "none" },
+    messages: [makeMessage("m1", "cached")],
+    ...overrides,
+  } as Session;
+}
+
+function makeGlobalSession(
+  id: string,
+  overrides: Partial<GlobalSessionItem> = {},
+): GlobalSessionItem {
+  return {
+    id,
+    title: `Session ${id}`,
+    createdAt: "2026-05-11T00:00:00.000Z",
+    updatedAt: "2026-05-11T00:00:00.000Z",
+    messageCount: 1,
+    provider: "codex",
+    projectId: "project-1",
+    projectName: "Project",
+    ownership: { owner: "none" },
+    ...overrides,
+  };
+}
+
+function makeStats(): GlobalSessionStats {
+  return {
+    totalCount: 1,
+    unreadCount: 0,
+    starredCount: 0,
+    archivedCount: 0,
+    providerCounts: { claude: 1 },
+    executorCounts: { local: 1 },
+  };
+}
+
+describe("session view cache", () => {
+  beforeEach(() => {
+    clearSessionViewCaches();
+    vi.clearAllMocks();
+  });
+
+  it("renders cached session messages immediately and skips full session fetch when metadata is unchanged", async () => {
+    const cachedSession = makeSession();
+    setCachedSessionDetail("project-1", "session-1", {
+      session: cachedSession,
+      messages: cachedSession.messages,
+      pagination: undefined,
+      agentContent: {},
+      toolUseToAgentEntries: [],
+      lastMessageId: "m1",
+    });
+
+    mockApi.getSessionMetadata.mockResolvedValue({
+      session: { ...cachedSession, messages: [] },
+      ownership: { owner: "none" },
+      pendingInputRequest: null,
+      slashCommands: null,
+    });
+
+    const { result } = renderHook(() =>
+      useSessionMessages({
+        projectId: "project-1",
+        sessionId: "session-1",
+      }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.messages).toEqual(cachedSession.messages);
+
+    await waitFor(() => {
+      expect(mockApi.getSessionMetadata).toHaveBeenCalledTimes(1);
+    });
+    expect(mockApi.getSession).not.toHaveBeenCalled();
+  });
+
+  it("uses afterMessageId and dedupes when cached session metadata changed", async () => {
+    const m1 = makeMessage("m1", "cached");
+    const m2 = makeMessage("m2", "new");
+    const cachedSession = makeSession({ messages: [m1] });
+    const updatedSession = makeSession({
+      updatedAt: "2026-05-11T00:01:00.000Z",
+      messageCount: 2,
+      messages: [m1, m2],
+    });
+
+    setCachedSessionDetail("project-1", "session-1", {
+      session: cachedSession,
+      messages: [m1],
+      pagination: undefined,
+      agentContent: {},
+      toolUseToAgentEntries: [],
+      lastMessageId: "m1",
+    });
+
+    mockApi.getSessionMetadata.mockResolvedValue({
+      session: { ...updatedSession, messages: [] },
+      ownership: { owner: "none" },
+      pendingInputRequest: null,
+      slashCommands: null,
+    });
+    mockApi.getSession.mockResolvedValue({
+      session: updatedSession,
+      messages: [m1, m2],
+      ownership: { owner: "none" },
+      pendingInputRequest: null,
+      slashCommands: null,
+    });
+
+    const { result } = renderHook(() =>
+      useSessionMessages({
+        projectId: "project-1",
+        sessionId: "session-1",
+      }),
+    );
+
+    expect(result.current.messages).toEqual([m1]);
+
+    await waitFor(() => {
+      expect(mockApi.getSession).toHaveBeenCalledWith(
+        "project-1",
+        "session-1",
+        "m1",
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.messages.map((m) => m.id)).toEqual(["m1", "m2"]);
+    });
+  });
+
+  it("reuses an unfinished initial session load after navigating away and back", async () => {
+    const loadedSession = makeSession();
+    let resolveSession:
+      | ((value: {
+          session: Session;
+          messages: Message[];
+          ownership: { owner: "none" };
+          pendingInputRequest: null;
+          slashCommands: null;
+        }) => void)
+      | undefined;
+    const pendingSession = new Promise<{
+      session: Session;
+      messages: Message[];
+      ownership: { owner: "none" };
+      pendingInputRequest: null;
+      slashCommands: null;
+    }>((resolve) => {
+      resolveSession = resolve;
+    });
+
+    mockApi.getSession.mockReturnValueOnce(pendingSession);
+
+    const first = renderHook(() =>
+      useSessionMessages({
+        projectId: "project-1",
+        sessionId: "session-1",
+      }),
+    );
+
+    expect(first.result.current.loading).toBe(true);
+    first.unmount();
+
+    const second = renderHook(() =>
+      useSessionMessages({
+        projectId: "project-1",
+        sessionId: "session-1",
+      }),
+    );
+
+    expect(mockApi.getSession).toHaveBeenCalledTimes(1);
+    expect(second.result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveSession?.({
+        session: loadedSession,
+        messages: loadedSession.messages,
+        ownership: { owner: "none" },
+        pendingInputRequest: null,
+        slashCommands: null,
+      });
+      await pendingSession;
+    });
+
+    await waitFor(() => {
+      expect(second.result.current.loading).toBe(false);
+    });
+    expect(second.result.current.messages.map((m) => m.id)).toEqual(["m1"]);
+    expect(mockApi.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders cached global sessions before background refresh updates them", async () => {
+    const cachedSessions: GlobalSessionItem[] = [
+      {
+        id: "cached-session",
+        title: "Cached",
+        createdAt: "2026-05-11T00:00:00.000Z",
+        updatedAt: "2026-05-11T00:00:01.000Z",
+        messageCount: 1,
+        provider: "claude",
+        projectId: "project-1",
+        projectName: "Project",
+        ownership: { owner: "none" },
+      },
+    ];
+    const cachedSession = cachedSessions[0];
+    if (!cachedSession) throw new Error("missing cached session fixture");
+    const freshSessions: GlobalSessionItem[] = [
+      {
+        ...cachedSession,
+        id: "fresh-session",
+        title: "Fresh",
+      },
+    ];
+    const projects: ProjectOption[] = [{ id: "project-1", name: "Project" }];
+
+    setCachedGlobalSessions(
+      { includeStats: true, limit: 100 },
+      {
+        sessions: cachedSessions,
+        stats: makeStats(),
+        projects,
+        hasMore: false,
+      },
+    );
+
+    mockApi.getGlobalSessions.mockResolvedValue({
+      sessions: freshSessions,
+      stats: makeStats(),
+      projects,
+      hasMore: false,
+    });
+    mockApi.getGlobalSessionStats.mockResolvedValue({ stats: makeStats() });
+
+    const { result } = renderHook(() =>
+      useGlobalSessions({ includeStats: true, limit: 100 }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.sessions.map((s) => s.id)).toEqual([
+      "cached-session",
+    ]);
+
+    await waitFor(() => {
+      expect(mockApi.getGlobalSessions).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.sessions.map((s) => s.id)).toEqual([
+        "fresh-session",
+      ]);
+    });
+  });
+
+  it("syncs session title updates between cached global session views", async () => {
+    const staleSession: GlobalSessionItem = {
+      id: "session-1",
+      title: "Old auto title",
+      createdAt: "2026-05-11T00:00:00.000Z",
+      updatedAt: "2026-05-11T00:00:01.000Z",
+      messageCount: 1,
+      provider: "claude",
+      projectId: "project-1",
+      projectName: "Project",
+      ownership: { owner: "none" },
+    };
+    const freshSession: GlobalSessionItem = {
+      ...staleSession,
+      customTitle: "Fresh custom title",
+      updatedAt: "2026-05-11T00:00:02.000Z",
+    };
+    const projects: ProjectOption[] = [{ id: "project-1", name: "Project" }];
+
+    setCachedGlobalSessions(
+      { limit: 50, includeStats: false },
+      {
+        sessions: [staleSession],
+        stats: makeStats(),
+        projects,
+        hasMore: false,
+      },
+    );
+
+    const never = new Promise<never>(() => {});
+    mockApi.getGlobalSessions.mockImplementation(
+      (params?: { project?: string }) => {
+        if (params?.project === "project-1") {
+          return Promise.resolve({
+            sessions: [freshSession],
+            stats: makeStats(),
+            projects,
+            hasMore: false,
+          });
+        }
+        return never;
+      },
+    );
+    mockApi.getGlobalSessionStats.mockResolvedValue({ stats: makeStats() });
+
+    const all = renderHook(() =>
+      useGlobalSessions({ includeStats: false, limit: 50 }),
+    );
+    const filtered = renderHook(() =>
+      useGlobalSessions({
+        projectId: "project-1",
+        includeStats: false,
+        limit: 50,
+      }),
+    );
+
+    expect(all.result.current.sessions[0]?.title).toBe("Old auto title");
+
+    await waitFor(() => {
+      expect(filtered.result.current.sessions[0]?.customTitle).toBe(
+        "Fresh custom title",
+      );
+    });
+    await waitFor(() => {
+      expect(all.result.current.sessions[0]?.customTitle).toBe(
+        "Fresh custom title",
+      );
+    });
+  });
+
+  it("prefetches only the five most recent 24h codex sessions with concurrency one", async () => {
+    const nowMs = Date.parse("2026-05-11T12:00:00.000Z");
+    const recentSessions = Array.from({ length: 6 }, (_, index) =>
+      makeGlobalSession(`recent-${index + 1}`, {
+        updatedAt: new Date(nowMs - index * 60_000).toISOString(),
+        messageCount: index + 1,
+      }),
+    );
+    const oldSession = makeGlobalSession("old-session", {
+      updatedAt: new Date(nowMs - 25 * 60 * 60_000).toISOString(),
+    });
+    const claudeSession = makeGlobalSession("claude-session", {
+      provider: "claude",
+      updatedAt: new Date(nowMs - 30_000).toISOString(),
+    });
+
+    const sessionById = new Map(
+      [...recentSessions, oldSession, claudeSession].map((session) => [
+        session.id,
+        session,
+      ]),
+    );
+    mockApi.getSessionMetadata.mockImplementation(
+      async (projectId: string, sessionId: string) => {
+        const source = sessionById.get(sessionId);
+        if (!source) throw new Error(`missing fixture: ${sessionId}`);
+        return {
+          session: makeSession({
+            id: sessionId,
+            projectId: projectId as Session["projectId"],
+            title: source.title,
+            updatedAt: source.updatedAt,
+            messageCount: source.messageCount,
+            provider: source.provider,
+            messages: [],
+          }),
+          ownership: { owner: "none" },
+          pendingInputRequest: null,
+          slashCommands: null,
+        };
+      },
+    );
+
+    const pendingLoads: Array<() => void> = [];
+    let activeLoads = 0;
+    let maxActiveLoads = 0;
+    mockApi.getSession.mockImplementation(
+      (
+        projectId: string,
+        sessionId: string,
+        afterMessageId?: string,
+        options?: { tailCompactions?: number },
+      ) => {
+        activeLoads++;
+        maxActiveLoads = Math.max(maxActiveLoads, activeLoads);
+        return new Promise((resolve) => {
+          pendingLoads.push(() => {
+            activeLoads--;
+            resolve({
+              session: makeSession({
+                id: sessionId,
+                projectId: projectId as Session["projectId"],
+                title: sessionById.get(sessionId)?.title,
+                updatedAt: sessionById.get(sessionId)?.updatedAt,
+                messageCount: sessionById.get(sessionId)?.messageCount,
+                provider: "codex",
+                messages: [makeMessage(`${sessionId}-m1`, "prefetched")],
+              }),
+              messages: [makeMessage(`${sessionId}-m1`, "prefetched")],
+              ownership: { owner: "none" },
+              pendingInputRequest: null,
+              slashCommands: null,
+              pagination: undefined,
+              afterMessageId,
+              options,
+            });
+          });
+        });
+      },
+    );
+
+    scheduleRecentSessionPrefetch(
+      [...recentSessions, oldSession, claudeSession],
+      {
+        nowMs,
+        debounceMs: 0,
+        tailCompactions: 1,
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockApi.getSession).toHaveBeenCalledTimes(1);
+    });
+    expect(mockApi.getSession).toHaveBeenLastCalledWith(
+      "project-1",
+      "recent-1",
+      undefined,
+      { tailCompactions: 1 },
+    );
+    expect(mockApi.getSessionMetadata).toHaveBeenCalledTimes(1);
+
+    for (let expected = 2; expected <= 5; expected++) {
+      await act(async () => {
+        pendingLoads.shift()?.();
+      });
+      await waitFor(() => {
+        expect(mockApi.getSession).toHaveBeenCalledTimes(expected);
+      });
+    }
+
+    await act(async () => {
+      pendingLoads.shift()?.();
+    });
+    await Promise.resolve();
+
+    expect(mockApi.getSession).toHaveBeenCalledTimes(5);
+    expect(mockApi.getSession.mock.calls.map((call) => call[1])).toEqual([
+      "recent-1",
+      "recent-2",
+      "recent-3",
+      "recent-4",
+      "recent-5",
+    ]);
+    expect(maxActiveLoads).toBe(1);
+  });
+
+  it("skips full prefetch when cached session metadata is unchanged", async () => {
+    const cachedSession = makeSession({
+      provider: "codex",
+      title: "Old title",
+      updatedAt: "2026-05-11T00:00:01.000Z",
+      messageCount: 1,
+    });
+    setCachedSessionDetail("project-1", "session-1", {
+      session: cachedSession,
+      messages: cachedSession.messages,
+      pagination: undefined,
+      agentContent: {},
+      toolUseToAgentEntries: [],
+      lastMessageId: "m1",
+    });
+
+    mockApi.getSessionMetadata.mockResolvedValue({
+      session: {
+        ...cachedSession,
+        title: "Codex generated title",
+        messages: [],
+      },
+      ownership: { owner: "none" },
+      pendingInputRequest: null,
+      slashCommands: null,
+    });
+
+    scheduleRecentSessionPrefetch(
+      [
+        makeGlobalSession("session-1", {
+          title: "Codex generated title",
+          updatedAt: cachedSession.updatedAt,
+          messageCount: cachedSession.messageCount,
+        }),
+      ],
+      { nowMs: Date.parse("2026-05-11T12:00:00.000Z"), debounceMs: 0 },
+    );
+
+    await waitFor(() => {
+      expect(mockApi.getSessionMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApi.getSession).not.toHaveBeenCalled();
+    expect(
+      getCachedSessionDetail("project-1", "session-1")?.session.title,
+    ).toBe("Codex generated title");
+  });
+
+  it("removes a queued prefetch when the user explicitly opens that session", async () => {
+    vi.useFakeTimers();
+
+    scheduleRecentSessionPrefetch([makeGlobalSession("session-1")], {
+      nowMs: Date.parse("2026-05-11T12:00:00.000Z"),
+      debounceMs: 1_000,
+    });
+    prioritizeSessionDetailLoad("project-1", "session-1");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(mockApi.getSessionMetadata).not.toHaveBeenCalled();
+    expect(mockApi.getSession).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+});

--- a/packages/client/src/hooks/sessionViewCache.ts
+++ b/packages/client/src/hooks/sessionViewCache.ts
@@ -1,0 +1,543 @@
+import type {
+  GlobalSessionItem,
+  GlobalSessionStats,
+  PaginationInfo,
+  ProjectOption,
+} from "../api/client";
+import { api } from "../api/client";
+import { reconcileCodexLinearMessages } from "../lib/codexLinearMessages";
+import { getMessageId, mergeJSONLMessages } from "../lib/mergeMessages";
+import { getProvider } from "../providers/registry";
+import type { Message, Session } from "../types";
+
+export interface CachedAgentContent {
+  messages: Message[];
+  status: "pending" | "running" | "completed" | "failed";
+  contextUsage?: {
+    inputTokens: number;
+    percentage: number;
+  };
+}
+
+export type CachedAgentContentMap = Record<string, CachedAgentContent>;
+
+export interface CachedSessionDetail {
+  session: Session;
+  messages: Message[];
+  pagination?: PaginationInfo;
+  agentContent: CachedAgentContentMap;
+  toolUseToAgentEntries: Array<[string, string]>;
+  lastMessageId?: string;
+}
+
+export interface GlobalSessionsCacheOptions {
+  projectId?: string | null;
+  project?: string | null;
+  searchQuery?: string;
+  q?: string;
+  limit?: number;
+  includeArchived?: boolean;
+  starred?: boolean;
+  includeStats?: boolean;
+}
+
+export interface CachedGlobalSessions {
+  sessions: GlobalSessionItem[];
+  stats: GlobalSessionStats;
+  projects: ProjectOption[];
+  hasMore: boolean;
+}
+
+export type GlobalSessionPatch = Partial<GlobalSessionItem> &
+  Pick<GlobalSessionItem, "id">;
+
+export interface RecentSessionPrefetchOptions {
+  nowMs?: number;
+  maxAgeMs?: number;
+  limit?: number;
+  debounceMs?: number;
+  tailCompactions?: 1 | 2;
+}
+
+interface RecentSessionPrefetchCandidate {
+  id: string;
+  projectId: string;
+  title: string | null;
+  updatedAt: string;
+  messageCount: number;
+  provider: GlobalSessionItem["provider"];
+  tailCompactions: 1 | 2;
+}
+
+const MAX_SESSION_DETAIL_ENTRIES = 30;
+const MAX_GLOBAL_SESSIONS_ENTRIES = 12;
+const RECENT_PREFETCH_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const RECENT_PREFETCH_LIMIT = 5;
+const RECENT_PREFETCH_DEBOUNCE_MS = 750;
+const RECENT_PREFETCH_TAIL_COMPACTIONS = 1;
+
+const sessionDetailCache = new Map<string, CachedSessionDetail>();
+const inFlightSessionDetailLoads = new Map<string, Promise<unknown>>();
+const globalSessionsCache = new Map<string, CachedGlobalSessions>();
+const globalSessionPatchListeners = new Set<
+  (patches: GlobalSessionPatch[]) => void
+>();
+const queuedPrefetchKeys = new Set<string>();
+const prefetchQueue: RecentSessionPrefetchCandidate[] = [];
+let scheduledPrefetchCandidates: RecentSessionPrefetchCandidate[] = [];
+let prefetchTimer: ReturnType<typeof setTimeout> | null = null;
+let prefetchRunning = false;
+
+function sessionDetailKey(projectId: string, sessionId: string): string {
+  return `${projectId}:${sessionId}`;
+}
+
+function globalSessionsKey(options: GlobalSessionsCacheOptions): string {
+  return JSON.stringify({
+    projectId: options.projectId ?? options.project ?? null,
+    searchQuery: options.searchQuery ?? options.q ?? "",
+    limit: options.limit ?? null,
+    includeArchived: options.includeArchived === true,
+    starred: options.starred === true,
+    includeStats: options.includeStats === true,
+  });
+}
+
+function evictOldest<K, V>(cache: Map<K, V>, maxEntries: number): void {
+  while (cache.size > maxEntries) {
+    const oldestKey = cache.keys().next().value as K | undefined;
+    if (oldestKey === undefined) return;
+    cache.delete(oldestKey);
+  }
+}
+
+function isCodexProvider(provider?: string): boolean {
+  return provider === "codex" || provider === "codex-oss";
+}
+
+function getLastCachedMessageId(messages: Message[]): string | undefined {
+  const lastMessage = messages[messages.length - 1];
+  return lastMessage ? getMessageId(lastMessage) : undefined;
+}
+
+function isCachedSessionFreshForCandidate(
+  cached: CachedSessionDetail | undefined,
+  candidate: RecentSessionPrefetchCandidate,
+): boolean {
+  if (!cached) return false;
+  return (
+    cached.session.updatedAt === candidate.updatedAt &&
+    cached.session.messageCount === candidate.messageCount &&
+    (cached.session.title ?? null) === (candidate.title ?? null)
+  );
+}
+
+function buildCachedLoadResult(
+  cached: CachedSessionDetail,
+): Awaited<ReturnType<typeof api.getSession>> & { lastMessageId?: string } {
+  return {
+    session: cached.session,
+    messages: cached.messages,
+    ownership: cached.session.ownership,
+    pendingInputRequest: null,
+    slashCommands: null,
+    pagination: cached.pagination,
+    lastMessageId:
+      cached.lastMessageId ?? getLastCachedMessageId(cached.messages),
+  };
+}
+
+function hydratePrefetchedSessionDetail(
+  data: Awaited<ReturnType<typeof api.getSession>>,
+  cached: CachedSessionDetail | null,
+): Awaited<ReturnType<typeof api.getSession>> & { lastMessageId?: string } {
+  const taggedMessages = data.messages.map((message) => ({
+    ...message,
+    _source: "jsonl" as const,
+  }));
+  const mergedMessages = cached
+    ? mergeJSONLMessages(cached.messages, taggedMessages, {
+        skipDagOrdering: !getProvider(data.session.provider).capabilities
+          .supportsDag,
+      }).messages
+    : taggedMessages;
+  const visibleMessages = isCodexProvider(data.session.provider)
+    ? reconcileCodexLinearMessages(mergedMessages)
+    : mergedMessages;
+  const hydratedSession = {
+    ...data.session,
+    messages: visibleMessages,
+  };
+  const lastMessageId = getLastCachedMessageId(visibleMessages);
+
+  return {
+    ...data,
+    session: hydratedSession,
+    messages: visibleMessages,
+    lastMessageId,
+  };
+}
+
+function buildRecentPrefetchCandidates(
+  sessions: GlobalSessionItem[],
+  options: RecentSessionPrefetchOptions,
+): RecentSessionPrefetchCandidate[] {
+  const nowMs = options.nowMs ?? Date.now();
+  const maxAgeMs = options.maxAgeMs ?? RECENT_PREFETCH_MAX_AGE_MS;
+  const limit = options.limit ?? RECENT_PREFETCH_LIMIT;
+  const tailCompactions =
+    options.tailCompactions ?? RECENT_PREFETCH_TAIL_COMPACTIONS;
+
+  return sessions
+    .filter((session) => isCodexProvider(session.provider))
+    .filter((session) => {
+      const updatedAtMs = Date.parse(session.updatedAt);
+      return Number.isFinite(updatedAtMs) && nowMs - updatedAtMs <= maxAgeMs;
+    })
+    .sort(
+      (a, b) =>
+        Date.parse(b.updatedAt) - Date.parse(a.updatedAt) ||
+        a.id.localeCompare(b.id),
+    )
+    .slice(0, limit)
+    .map((session) => ({
+      id: session.id,
+      projectId: session.projectId,
+      title: session.title,
+      updatedAt: session.updatedAt,
+      messageCount: session.messageCount,
+      provider: session.provider,
+      tailCompactions,
+    }));
+}
+
+function cloneAgentContent(
+  agentContent: CachedAgentContentMap,
+): CachedAgentContentMap {
+  return Object.fromEntries(
+    Object.entries(agentContent).map(([agentId, content]) => [
+      agentId,
+      {
+        ...content,
+        messages: [...content.messages],
+        contextUsage: content.contextUsage
+          ? { ...content.contextUsage }
+          : undefined,
+      },
+    ]),
+  );
+}
+
+function cloneSessionDetail(entry: CachedSessionDetail): CachedSessionDetail {
+  return {
+    ...entry,
+    session: { ...entry.session, messages: [...entry.messages] },
+    messages: [...entry.messages],
+    pagination: entry.pagination ? { ...entry.pagination } : undefined,
+    agentContent: cloneAgentContent(entry.agentContent),
+    toolUseToAgentEntries: [...entry.toolUseToAgentEntries],
+  };
+}
+
+function cloneGlobalSessions(
+  entry: CachedGlobalSessions,
+): CachedGlobalSessions {
+  return {
+    sessions: [...entry.sessions],
+    stats: {
+      ...entry.stats,
+      providerCounts: { ...entry.stats.providerCounts },
+      executorCounts: { ...entry.stats.executorCounts },
+    },
+    projects: [...entry.projects],
+    hasMore: entry.hasMore,
+  };
+}
+
+export function getCachedSessionDetail(
+  projectId: string,
+  sessionId: string,
+): CachedSessionDetail | null {
+  const key = sessionDetailKey(projectId, sessionId);
+  const entry = sessionDetailCache.get(key);
+  if (!entry) return null;
+
+  sessionDetailCache.delete(key);
+  sessionDetailCache.set(key, entry);
+  return cloneSessionDetail(entry);
+}
+
+export function setCachedSessionDetail(
+  projectId: string,
+  sessionId: string,
+  entry: CachedSessionDetail,
+): void {
+  const key = sessionDetailKey(projectId, sessionId);
+  sessionDetailCache.delete(key);
+  sessionDetailCache.set(key, cloneSessionDetail(entry));
+  evictOldest(sessionDetailCache, MAX_SESSION_DETAIL_ENTRIES);
+}
+
+export function getInFlightSessionDetailLoad<T>(
+  projectId: string,
+  sessionId: string,
+): Promise<T> | null {
+  const promise = inFlightSessionDetailLoads.get(
+    sessionDetailKey(projectId, sessionId),
+  );
+  return promise ? (promise as Promise<T>) : null;
+}
+
+export function setInFlightSessionDetailLoad<T>(
+  projectId: string,
+  sessionId: string,
+  promise: Promise<T>,
+): Promise<T> {
+  const key = sessionDetailKey(projectId, sessionId);
+  inFlightSessionDetailLoads.set(key, promise);
+  promise.finally(() => {
+    if (inFlightSessionDetailLoads.get(key) === promise) {
+      inFlightSessionDetailLoads.delete(key);
+    }
+  });
+  return promise;
+}
+
+export function getCachedGlobalSessions(
+  options: GlobalSessionsCacheOptions,
+): CachedGlobalSessions | null {
+  const key = globalSessionsKey(options);
+  const entry = globalSessionsCache.get(key);
+  if (!entry) return null;
+
+  globalSessionsCache.delete(key);
+  globalSessionsCache.set(key, entry);
+  return cloneGlobalSessions(entry);
+}
+
+export function setCachedGlobalSessions(
+  options: GlobalSessionsCacheOptions,
+  entry: CachedGlobalSessions,
+): void {
+  const key = globalSessionsKey(options);
+  globalSessionsCache.delete(key);
+  globalSessionsCache.set(key, cloneGlobalSessions(entry));
+  evictOldest(globalSessionsCache, MAX_GLOBAL_SESSIONS_ENTRIES);
+}
+
+export function patchCachedGlobalSessions(
+  patches: GlobalSessionPatch | GlobalSessionPatch[],
+): void {
+  const patchList = Array.isArray(patches) ? patches : [patches];
+  if (patchList.length === 0) return;
+
+  const patchById = new Map(patchList.map((patch) => [patch.id, patch]));
+
+  for (const [key, entry] of globalSessionsCache.entries()) {
+    let changed = false;
+    const sessions = entry.sessions.map((session) => {
+      const patch = patchById.get(session.id);
+      if (!patch) return session;
+      changed = true;
+      return { ...session, ...patch };
+    });
+
+    if (changed) {
+      globalSessionsCache.set(key, cloneGlobalSessions({ ...entry, sessions }));
+    }
+  }
+
+  for (const listener of globalSessionPatchListeners) {
+    listener(patchList);
+  }
+}
+
+export function subscribeToGlobalSessionPatches(
+  listener: (patches: GlobalSessionPatch[]) => void,
+): () => void {
+  globalSessionPatchListeners.add(listener);
+  return () => {
+    globalSessionPatchListeners.delete(listener);
+  };
+}
+
+async function prefetchSessionDetail(
+  candidate: RecentSessionPrefetchCandidate,
+): Promise<
+  Awaited<ReturnType<typeof api.getSession>> & {
+    lastMessageId?: string;
+  }
+> {
+  const cached = getCachedSessionDetail(candidate.projectId, candidate.id);
+
+  const metadata = await api.getSessionMetadata(
+    candidate.projectId,
+    candidate.id,
+  );
+
+  if (cached) {
+    const metadataUnchanged =
+      metadata.session.updatedAt === cached.session.updatedAt &&
+      metadata.session.messageCount === cached.session.messageCount;
+
+    if (metadataUnchanged) {
+      const refreshedSession = {
+        ...cached.session,
+        ...metadata.session,
+        messages: cached.messages,
+      };
+      const refreshed = {
+        ...cached,
+        session: refreshedSession,
+        messages: cached.messages,
+      };
+      setCachedSessionDetail(candidate.projectId, candidate.id, refreshed);
+      return buildCachedLoadResult(refreshed);
+    }
+  }
+
+  const afterMessageId =
+    cached?.lastMessageId ?? getLastCachedMessageId(cached?.messages ?? []);
+  const data = await api.getSession(
+    candidate.projectId,
+    candidate.id,
+    afterMessageId,
+    {
+      tailCompactions: candidate.tailCompactions,
+    },
+  );
+  const hydrated = hydratePrefetchedSessionDetail(data, cached);
+
+  setCachedSessionDetail(candidate.projectId, candidate.id, {
+    session: hydrated.session,
+    messages: hydrated.messages,
+    pagination: hydrated.pagination,
+    agentContent: cached?.agentContent ?? {},
+    toolUseToAgentEntries: cached?.toolUseToAgentEntries ?? [],
+    lastMessageId: hydrated.lastMessageId,
+  });
+
+  return hydrated;
+}
+
+function runPrefetchQueue(): void {
+  if (prefetchRunning) return;
+
+  const candidate = prefetchQueue.shift();
+  if (!candidate) return;
+
+  const key = sessionDetailKey(candidate.projectId, candidate.id);
+  queuedPrefetchKeys.delete(key);
+
+  const cached = sessionDetailCache.get(key);
+  if (
+    inFlightSessionDetailLoads.has(key) ||
+    isCachedSessionFreshForCandidate(cached, candidate)
+  ) {
+    runPrefetchQueue();
+    return;
+  }
+
+  prefetchRunning = true;
+  setInFlightSessionDetailLoad(
+    candidate.projectId,
+    candidate.id,
+    prefetchSessionDetail(candidate),
+  )
+    .catch(() => {
+      // Prefetch must never surface errors or disturb the visible UI.
+    })
+    .finally(() => {
+      prefetchRunning = false;
+      runPrefetchQueue();
+    });
+}
+
+function enqueueScheduledPrefetches(): void {
+  const candidates = scheduledPrefetchCandidates;
+  scheduledPrefetchCandidates = [];
+
+  for (const candidate of candidates) {
+    const key = sessionDetailKey(candidate.projectId, candidate.id);
+    const cached = sessionDetailCache.get(key);
+    if (
+      queuedPrefetchKeys.has(key) ||
+      inFlightSessionDetailLoads.has(key) ||
+      isCachedSessionFreshForCandidate(cached, candidate)
+    ) {
+      continue;
+    }
+
+    queuedPrefetchKeys.add(key);
+    prefetchQueue.push(candidate);
+  }
+
+  runPrefetchQueue();
+}
+
+export function scheduleRecentSessionPrefetch(
+  sessions: GlobalSessionItem[],
+  options: RecentSessionPrefetchOptions = {},
+): void {
+  const candidates = buildRecentPrefetchCandidates(sessions, options);
+  if (candidates.length === 0) {
+    scheduledPrefetchCandidates = [];
+    if (prefetchTimer) {
+      clearTimeout(prefetchTimer);
+      prefetchTimer = null;
+    }
+    return;
+  }
+
+  scheduledPrefetchCandidates = candidates;
+
+  if (prefetchTimer) {
+    clearTimeout(prefetchTimer);
+    prefetchTimer = null;
+  }
+
+  const debounceMs = options.debounceMs ?? RECENT_PREFETCH_DEBOUNCE_MS;
+  if (debounceMs <= 0) {
+    enqueueScheduledPrefetches();
+    return;
+  }
+
+  prefetchTimer = setTimeout(() => {
+    prefetchTimer = null;
+    enqueueScheduledPrefetches();
+  }, debounceMs);
+}
+
+export function prioritizeSessionDetailLoad(
+  projectId: string,
+  sessionId: string,
+): void {
+  const key = sessionDetailKey(projectId, sessionId);
+  queuedPrefetchKeys.delete(key);
+  scheduledPrefetchCandidates = scheduledPrefetchCandidates.filter(
+    (candidate) => sessionDetailKey(candidate.projectId, candidate.id) !== key,
+  );
+
+  for (let index = prefetchQueue.length - 1; index >= 0; index--) {
+    const candidate = prefetchQueue[index];
+    if (!candidate) continue;
+    if (sessionDetailKey(candidate.projectId, candidate.id) === key) {
+      prefetchQueue.splice(index, 1);
+    }
+  }
+}
+
+export function clearSessionViewCaches(): void {
+  sessionDetailCache.clear();
+  inFlightSessionDetailLoads.clear();
+  globalSessionsCache.clear();
+  globalSessionPatchListeners.clear();
+  queuedPrefetchKeys.clear();
+  prefetchQueue.length = 0;
+  scheduledPrefetchCandidates = [];
+  prefetchRunning = false;
+  if (prefetchTimer) {
+    clearTimeout(prefetchTimer);
+    prefetchTimer = null;
+  }
+}

--- a/packages/client/src/hooks/useGlobalSessions.ts
+++ b/packages/client/src/hooks/useGlobalSessions.ts
@@ -1,10 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type GlobalSessionItem,
   type GlobalSessionStats,
   type ProjectOption,
   api,
 } from "../api/client";
+import {
+  type GlobalSessionPatch,
+  getCachedGlobalSessions,
+  patchCachedGlobalSessions,
+  scheduleRecentSessionPrefetch,
+  setCachedGlobalSessions,
+  subscribeToGlobalSessionPatches,
+} from "./sessionViewCache";
 import {
   type ProcessStateEvent,
   type SessionCreatedEvent,
@@ -45,18 +53,97 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     starred,
     includeStats = false,
   } = options;
-  const [sessions, setSessions] = useState<GlobalSessionItem[]>([]);
-  const [stats, setStats] = useState<GlobalSessionStats>(DEFAULT_STATS);
-  const [projects, setProjects] = useState<ProjectOption[]>([]);
-  const [loading, setLoading] = useState(true);
+  const cacheOptions = useMemo(
+    () => ({
+      projectId,
+      searchQuery,
+      limit,
+      includeArchived,
+      starred,
+      includeStats,
+    }),
+    [projectId, searchQuery, limit, includeArchived, starred, includeStats],
+  );
+  const initialCachedRef = useRef(getCachedGlobalSessions(cacheOptions));
+  const initialCached = initialCachedRef.current;
+  const [sessions, setSessions] = useState<GlobalSessionItem[]>(
+    () => initialCached?.sessions ?? [],
+  );
+  const [stats, setStats] = useState<GlobalSessionStats>(
+    () => initialCached?.stats ?? DEFAULT_STATS,
+  );
+  const [projects, setProjects] = useState<ProjectOption[]>(
+    () => initialCached?.projects ?? [],
+  );
+  const [loading, setLoading] = useState(() => !initialCached);
   const [error, setError] = useState<Error | null>(null);
-  const [hasMore, setHasMore] = useState(false);
+  const [hasMore, setHasMore] = useState(() => initialCached?.hasMore ?? false);
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasInitialLoadRef = useRef(false);
   const sessionsRef = useRef<GlobalSessionItem[]>([]);
   sessionsRef.current = sessions;
   const projectsRef = useRef<ProjectOption[]>([]);
   projectsRef.current = projects;
+
+  const sessionMatchesCurrentFilters = useCallback(
+    (session: GlobalSessionItem): boolean => {
+      if (projectId && session.projectId !== projectId) return false;
+      if (!includeArchived && session.isArchived) return false;
+      if (starred && !session.isStarred) return false;
+
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const titleMatch = session.title?.toLowerCase().includes(q);
+        const customTitleMatch = session.customTitle?.toLowerCase().includes(q);
+        const projectNameMatch = session.projectName.toLowerCase().includes(q);
+        if (!titleMatch && !customTitleMatch && !projectNameMatch) {
+          return false;
+        }
+      }
+
+      return true;
+    },
+    [projectId, includeArchived, starred, searchQuery],
+  );
+
+  const applySessionPatches = useCallback(
+    (patches: GlobalSessionPatch[]) => {
+      const patchById = new Map(patches.map((patch) => [patch.id, patch]));
+      setSessions((prev) => {
+        let changed = false;
+        const next: GlobalSessionItem[] = [];
+
+        for (const session of prev) {
+          const patch = patchById.get(session.id);
+          const merged = patch ? { ...session, ...patch } : session;
+          if (patch) changed = true;
+
+          if (sessionMatchesCurrentFilters(merged)) {
+            next.push(merged);
+          } else {
+            changed = true;
+          }
+        }
+
+        return changed ? next : prev;
+      });
+    },
+    [sessionMatchesCurrentFilters],
+  );
+
+  useEffect(() => {
+    return subscribeToGlobalSessionPatches(applySessionPatches);
+  }, [applySessionPatches]);
+
+  useEffect(() => {
+    if (!hasInitialLoadRef.current) return;
+    setCachedGlobalSessions(cacheOptions, {
+      sessions,
+      stats,
+      projects,
+      hasMore,
+    });
+  }, [cacheOptions, sessions, stats, projects, hasMore]);
 
   // Track the options used for the last fetch (for loadMore pagination)
   const lastFetchOptionsRef = useRef<{
@@ -73,12 +160,22 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     const optionsChanged =
       lastFetchOptionsRef.current.projectId !== projectId ||
       lastFetchOptionsRef.current.searchQuery !== searchQuery ||
+      lastFetchOptionsRef.current.limit !== limit ||
       lastFetchOptionsRef.current.includeArchived !== includeArchived ||
       lastFetchOptionsRef.current.starred !== starred ||
       lastFetchOptionsRef.current.includeStats !== includeStats;
 
+    const cachedForOptions = getCachedGlobalSessions(cacheOptions);
     if (optionsChanged) {
-      hasInitialLoadRef.current = false;
+      if (cachedForOptions) {
+        setSessions(cachedForOptions.sessions);
+        setStats(cachedForOptions.stats);
+        setProjects(cachedForOptions.projects);
+        setHasMore(cachedForOptions.hasMore);
+        hasInitialLoadRef.current = true;
+      } else {
+        hasInitialLoadRef.current = false;
+      }
     }
 
     lastFetchOptionsRef.current = {
@@ -91,7 +188,10 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     };
 
     // Only show loading state on initial load
-    if (sessionsRef.current.length === 0 || optionsChanged) {
+    if (
+      !cachedForOptions &&
+      (sessionsRef.current.length === 0 || optionsChanged)
+    ) {
       setLoading(true);
     }
     setError(null);
@@ -112,6 +212,9 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
         sessionsPromise,
         statsPromise,
       ]);
+
+      patchCachedGlobalSessions(data.sessions);
+      scheduleRecentSessionPrefetch(data.sessions);
 
       if (!hasInitialLoadRef.current || optionsChanged) {
         setSessions(data.sessions);
@@ -148,7 +251,15 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
     } finally {
       setLoading(false);
     }
-  }, [projectId, searchQuery, limit, includeArchived, starred, includeStats]);
+  }, [
+    projectId,
+    searchQuery,
+    limit,
+    includeArchived,
+    starred,
+    includeStats,
+    cacheOptions,
+  ]);
 
   // Load more sessions (pagination)
   const loadMore = useCallback(async () => {
@@ -167,6 +278,8 @@ export function useGlobalSessions(options: UseGlobalSessionsOptions = {}) {
         starred,
         includeStats: false,
       });
+
+      patchCachedGlobalSessions(data.sessions);
 
       setSessions((prev) => {
         // Deduplicate when appending

--- a/packages/client/src/hooks/useSession.ts
+++ b/packages/client/src/hooks/useSession.ts
@@ -301,6 +301,9 @@ export function useSession(
     timer: ReturnType<typeof setTimeout> | null;
     pending: boolean;
   }>({ timer: null, pending: false });
+  const activityRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   // Add a message to the pending queue
   // Generates a tempId that will be sent to the server and echoed back in stream
@@ -548,24 +551,45 @@ export function useSession(
     [projectId, sessionId],
   );
 
-  // Handle activity bus reconnection (e.g., after phone screen wake).
-  // Catches up on messages and ownership changes that occurred while disconnected.
-  // Without this, a session that completed while the screen was off would show stale
-  // data because the session stream unsubscribes when ownership becomes "none" and
-  // nobody triggers fetchNewMessages().
-  const handleActivityReconnect = useCallback(async () => {
-    fetchNewMessages();
-    try {
-      const data = await api.getSessionMetadata(projectId, sessionId);
-      setStatus(data.ownership);
-      if (data.ownership.owner === "none") {
-        setProcessState("idle");
-        setPendingInputRequest(null);
-      }
-    } catch {
-      // Silent fail - non-critical
+  const runActivityReconnectRefresh = useCallback(async () => {
+    const previousUpdatedAt = session?.updatedAt;
+    const previousMessageCount = session?.messageCount;
+    const result = await fetchSessionMetadata();
+    if (!result) return;
+
+    setStatus(result.status);
+    if (result.pendingInputRequest) {
+      setPendingInputRequest(result.pendingInputRequest as InputRequest);
+    } else if (result.status.owner === "none") {
+      setPendingInputRequest(null);
     }
-  }, [projectId, sessionId, fetchNewMessages]);
+    if (result.slashCommands?.length) {
+      setSlashCommands(result.slashCommands.map((c) => c.name));
+    }
+    if (result.status.owner === "none") {
+      setProcessState("idle");
+    }
+
+    const changed =
+      !session ||
+      result.session.updatedAt !== previousUpdatedAt ||
+      result.session.messageCount !== previousMessageCount;
+    if (changed) {
+      fetchNewMessages();
+    }
+  }, [session, fetchSessionMetadata, fetchNewMessages]);
+
+  // Handle activity bus reconnection (e.g., after phone screen wake).
+  // Keep the visible cached view in place, then debounce a metadata-first catch-up.
+  const handleActivityReconnect = useCallback(() => {
+    if (activityRefreshTimerRef.current) {
+      clearTimeout(activityRefreshTimerRef.current);
+    }
+    activityRefreshTimerRef.current = setTimeout(() => {
+      activityRefreshTimerRef.current = null;
+      runActivityReconnectRefresh();
+    }, 250);
+  }, [runActivityReconnectRefresh]);
 
   useFileActivity({
     onSessionStatusChange: handleSessionStatusChange,
@@ -601,6 +625,9 @@ export function useSession(
     return () => {
       if (throttleRef.current.timer) {
         clearTimeout(throttleRef.current.timer);
+      }
+      if (activityRefreshTimerRef.current) {
+        clearTimeout(activityRefreshTimerRef.current);
       }
     };
   }, []);

--- a/packages/client/src/hooks/useSessionMessages.ts
+++ b/packages/client/src/hooks/useSessionMessages.ts
@@ -12,6 +12,13 @@ import {
 } from "../lib/mergeMessages";
 import { getProvider } from "../providers/registry";
 import type { Message, Session, SessionStatus } from "../types";
+import {
+  getCachedSessionDetail,
+  getInFlightSessionDetailLoad,
+  prioritizeSessionDetailLoad,
+  setCachedSessionDetail,
+  setInFlightSessionDetailLoad,
+} from "./sessionViewCache";
 
 /** Content from a subagent (Task tool) */
 export interface AgentContent {
@@ -38,6 +45,12 @@ export interface SessionLoadResult {
     argumentHint?: string;
   }> | null;
 }
+
+export type SessionMetadataResult = SessionLoadResult | null;
+
+type InitialSessionLoadData = Awaited<ReturnType<typeof api.getSession>> & {
+  lastMessageId?: string;
+};
 
 /** Options for useSessionMessages */
 export interface UseSessionMessagesOptions {
@@ -80,7 +93,7 @@ export interface UseSessionMessagesResult {
   /** Fetch new messages incrementally (for file change events) */
   fetchNewMessages: () => Promise<void>;
   /** Fetch session metadata only */
-  fetchSessionMetadata: () => Promise<void>;
+  fetchSessionMetadata: () => Promise<SessionMetadataResult>;
   /** Pagination info from compact-boundary-based loading */
   pagination: PaginationInfo | undefined;
   /** Whether older messages are being loaded */
@@ -143,6 +156,11 @@ function isEmptyAssistantContent(message: Message): boolean {
   });
 }
 
+function getLastCachedMessageId(messages: Message[]): string | undefined {
+  const lastMessage = messages[messages.length - 1];
+  return lastMessage ? getMessageId(lastMessage) : undefined;
+}
+
 /**
  * Hook for managing session messages with stream buffering.
  *
@@ -156,16 +174,26 @@ export function useSessionMessages(
   options: UseSessionMessagesOptions,
 ): UseSessionMessagesResult {
   const { projectId, sessionId, onLoadComplete, onLoadError } = options;
+  const initialCachedRef = useRef(getCachedSessionDetail(projectId, sessionId));
+  const initialCached = initialCachedRef.current;
 
   // Core state
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [agentContent, setAgentContent] = useState<AgentContentMap>({});
-  const [toolUseToAgent, setToolUseToAgent] = useState<Map<string, string>>(
-    () => new Map(),
+  const [messages, setMessages] = useState<Message[]>(
+    () => initialCached?.messages ?? [],
   );
-  const [loading, setLoading] = useState(true);
-  const [session, setSession] = useState<Session | null>(null);
-  const [pagination, setPagination] = useState<PaginationInfo | undefined>();
+  const [agentContent, setAgentContent] = useState<AgentContentMap>(
+    () => initialCached?.agentContent ?? {},
+  );
+  const [toolUseToAgent, setToolUseToAgent] = useState<Map<string, string>>(
+    () => new Map(initialCached?.toolUseToAgentEntries ?? []),
+  );
+  const [loading, setLoading] = useState(() => !initialCached);
+  const [session, setSession] = useState<Session | null>(
+    () => initialCached?.session ?? null,
+  );
+  const [pagination, setPagination] = useState<PaginationInfo | undefined>(
+    () => initialCached?.pagination,
+  );
   const [loadingOlder, setLoadingOlder] = useState(false);
 
   // Buffering: queue stream messages until initial load completes
@@ -178,10 +206,17 @@ export function useSessionMessages(
   const initialLoadCompleteRef = useRef(false);
 
   // Track provider for DAG ordering decisions
-  const providerRef = useRef<string | undefined>(undefined);
+  const providerRef = useRef<string | undefined>(
+    initialCached?.session.provider,
+  );
 
   // Track last message ID for incremental fetching
-  const lastMessageIdRef = useRef<string | undefined>(undefined);
+  const lastMessageIdRef = useRef<string | undefined>(
+    initialCached?.lastMessageId ??
+      (initialCached
+        ? getLastCachedMessageId(initialCached.messages)
+        : undefined),
+  );
   // Highest timestamp observed from persisted JSONL messages.
   // Used to suppress startup replay events that are already on disk.
   const maxPersistedTimestampMsRef = useRef<number>(Number.NEGATIVE_INFINITY);
@@ -207,6 +242,28 @@ export function useSessionMessages(
       lastMessageIdRef.current = getMessageId(lastMessage);
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (!session || !initialLoadCompleteRef.current) return;
+
+    const lastMessageId = getLastCachedMessageId(messages);
+    setCachedSessionDetail(projectId, sessionId, {
+      session: { ...session, messages },
+      messages,
+      pagination,
+      agentContent,
+      toolUseToAgentEntries: Array.from(toolUseToAgent.entries()),
+      lastMessageId,
+    });
+  }, [
+    projectId,
+    sessionId,
+    session,
+    messages,
+    pagination,
+    agentContent,
+    toolUseToAgent,
+  ]);
 
   // Process a stream message event.
   // When replaying buffered startup events for Codex, suppress entries that are
@@ -288,38 +345,153 @@ export function useSessionMessages(
 
   // Initial load
   useEffect(() => {
+    let cancelled = false;
+    prioritizeSessionDetailLoad(projectId, sessionId);
+    const cached = getCachedSessionDetail(projectId, sessionId);
+
     initialLoadCompleteRef.current = false;
     streamBufferRef.current = [];
     maxPersistedTimestampMsRef.current = Number.NEGATIVE_INFINITY;
-    setLoading(true);
-    setAgentContent({});
 
-    api
-      .getSession(projectId, sessionId, undefined, { tailCompactions: 2 })
+    if (cached) {
+      providerRef.current = cached.session.provider;
+      lastMessageIdRef.current =
+        cached.lastMessageId ?? getLastCachedMessageId(cached.messages);
+      updatePersistedTimestampWatermark(cached.messages);
+
+      setSession(cached.session);
+      setPagination(cached.pagination);
+      setMessages(cached.messages);
+      setAgentContent(cached.agentContent);
+      setToolUseToAgent(new Map(cached.toolUseToAgentEntries));
+      setLoading(false);
+
+      initialLoadCompleteRef.current = true;
+      flushBuffer();
+
+      api
+        .getSessionMetadata(projectId, sessionId)
+        .then(async (metadata) => {
+          if (cancelled) return;
+
+          setSession((prev) =>
+            prev
+              ? { ...prev, ...metadata.session, messages: prev.messages }
+              : { ...metadata.session, messages: cached.messages },
+          );
+
+          onLoadComplete?.({
+            session: metadata.session,
+            status: metadata.ownership,
+            pendingInputRequest: metadata.pendingInputRequest,
+            slashCommands: metadata.slashCommands,
+          });
+
+          const unchanged =
+            metadata.session.updatedAt === cached.session.updatedAt &&
+            metadata.session.messageCount === cached.session.messageCount;
+          if (unchanged) return;
+
+          const data = await api.getSession(
+            projectId,
+            sessionId,
+            lastMessageIdRef.current,
+          );
+          if (cancelled) return;
+
+          if (data.messages.length > 0) {
+            updatePersistedTimestampWatermark(data.messages);
+            setMessages((prev) => {
+              const result = mergeJSONLMessages(prev, data.messages, {
+                skipDagOrdering: !getProvider(data.session.provider)
+                  .capabilities.supportsDag,
+              });
+              return isCodexProvider(data.session.provider)
+                ? reconcileCodexLinearMessages(result.messages)
+                : result.messages;
+            });
+          }
+
+          setSession((prev) =>
+            prev
+              ? { ...prev, ...data.session, messages: prev.messages }
+              : data.session,
+          );
+        })
+        .catch(() => {
+          // Cached data is already visible; background refresh failure should not blank it.
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setLoading(true);
+    setSession(null);
+    setPagination(undefined);
+    setMessages([]);
+    setAgentContent({});
+    setToolUseToAgent(new Map());
+
+    const loadSession =
+      getInFlightSessionDetailLoad<InitialSessionLoadData>(
+        projectId,
+        sessionId,
+      ) ??
+      setInFlightSessionDetailLoad(
+        projectId,
+        sessionId,
+        api
+          .getSession(projectId, sessionId, undefined, { tailCompactions: 2 })
+          .then((data): InitialSessionLoadData => {
+            const taggedMessages = data.messages.map((m) => ({
+              ...m,
+              _source: "jsonl" as const,
+            }));
+            const visibleMessages = isCodexProvider(data.session.provider)
+              ? reconcileCodexLinearMessages(taggedMessages)
+              : taggedMessages;
+            const hydratedSession = {
+              ...data.session,
+              messages: visibleMessages,
+            };
+            const lastMessageId = getLastCachedMessageId(visibleMessages);
+
+            setCachedSessionDetail(projectId, sessionId, {
+              session: hydratedSession,
+              messages: visibleMessages,
+              pagination: data.pagination,
+              agentContent: {},
+              toolUseToAgentEntries: [],
+              lastMessageId,
+            });
+
+            return {
+              ...data,
+              session: hydratedSession,
+              messages: visibleMessages,
+              lastMessageId,
+            };
+          }),
+      );
+
+    loadSession
       .then((data) => {
+        if (cancelled) return;
         setSession(data.session);
         setPagination(data.pagination);
         providerRef.current = data.session.provider;
 
-        // Tag messages from JSONL as authoritative
-        const taggedMessages = data.messages.map((m) => ({
-          ...m,
-          _source: "jsonl" as const,
-        }));
-        updatePersistedTimestampWatermark(taggedMessages);
-        setMessages(
-          isCodexProvider(data.session.provider)
-            ? reconcileCodexLinearMessages(taggedMessages)
-            : taggedMessages,
-        );
+        updatePersistedTimestampWatermark(data.messages);
+        setMessages(data.messages);
 
         // Update lastMessageIdRef synchronously to avoid race condition:
         // stream "connected" event calls fetchNewMessages() immediately, but the
         // useEffect that normally updates lastMessageIdRef runs asynchronously.
         // Without this, fetchNewMessages() would use undefined and refetch everything.
-        const lastMessage = taggedMessages[taggedMessages.length - 1];
-        if (lastMessage) {
-          lastMessageIdRef.current = getMessageId(lastMessage);
+        if (data.lastMessageId) {
+          lastMessageIdRef.current = data.lastMessageId;
         }
 
         // Mark ready and flush buffer
@@ -337,9 +509,14 @@ export function useSessionMessages(
         });
       })
       .catch((err) => {
+        if (cancelled) return;
         setLoading(false);
         onLoadError?.(err);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     projectId,
     sessionId,
@@ -511,8 +688,15 @@ export function useSessionMessages(
           ? { ...prev, ...data.session, messages: prev.messages }
           : { ...data.session, messages: [] },
       );
+      return {
+        session: data.session,
+        status: data.ownership,
+        pendingInputRequest: data.pendingInputRequest,
+        slashCommands: data.slashCommands,
+      };
     } catch {
       // Silent fail for metadata updates
+      return null;
     }
   }, [projectId, sessionId]);
 

--- a/packages/server/src/indexes/SessionIndexService.ts
+++ b/packages/server/src/indexes/SessionIndexService.ts
@@ -39,6 +39,8 @@ export interface CachedSessionSummary {
   indexedBytes: number;
   /** File mtime in milliseconds since epoch at time of indexing */
   fileMtime: number;
+  /** Optional reader-owned dependency token for summary fields outside the session file. */
+  summaryCacheToken?: string | null;
   /** True if session has no user/assistant messages (metadata-only file) */
   isEmpty?: boolean;
   /** AI provider for this session */
@@ -476,6 +478,7 @@ export class SessionIndexService implements ISessionIndexService {
     summary: SessionSummary,
     mtime: number,
     size: number,
+    summaryCacheToken?: string | null,
   ): CachedSessionSummary {
     return {
       title: summary.title,
@@ -486,6 +489,7 @@ export class SessionIndexService implements ISessionIndexService {
       contextUsage: summary.contextUsage,
       indexedBytes: size,
       fileMtime: mtime,
+      summaryCacheToken,
       provider: summary.provider,
       model: summary.model,
     };
@@ -530,6 +534,26 @@ export class SessionIndexService implements ISessionIndexService {
         `[SessionIndexService] mode=${mode} dir=${sessionDir} durationMs=${durationMs} statCalls=${statCalls} parseCalls=${parseCalls}`,
       );
     }
+  }
+
+  private async getSummaryCacheToken(
+    reader: ISessionReader,
+    sessionId: string,
+  ): Promise<string | null | undefined> {
+    if (!reader.getSummaryCacheToken) return undefined;
+
+    try {
+      return await reader.getSummaryCacheToken(sessionId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private summaryCacheTokenMatches(
+    cached: CachedSessionSummary,
+    token: string | null | undefined,
+  ): boolean {
+    return token === undefined || cached.summaryCacheToken === token;
   }
 
   /**
@@ -608,6 +632,7 @@ export class SessionIndexService implements ISessionIndexService {
           changed.summary,
           changed.mtime,
           changed.size,
+          await this.getSummaryCacheToken(reader, sessionId),
         );
         indexChanged = true;
         continue;
@@ -627,6 +652,7 @@ export class SessionIndexService implements ISessionIndexService {
             summary,
             stats.mtimeMs,
             stats.size,
+            await this.getSummaryCacheToken(reader, sessionId),
           );
           indexChanged = true;
         } catch {
@@ -707,6 +733,7 @@ export class SessionIndexService implements ISessionIndexService {
         sessionId: string;
         mtime: number;
         size: number;
+        summaryCacheToken?: string | null;
       }[] = [];
 
       for (let i = 0; i < sessionFiles.length; i++) {
@@ -722,10 +749,16 @@ export class SessionIndexService implements ISessionIndexService {
         const mtime = stats.mtimeMs;
         const size = stats.size;
 
+        const summaryCacheToken =
+          cached && cached.fileMtime === mtime && cached.indexedBytes === size
+            ? await this.getSummaryCacheToken(reader, sessionId)
+            : undefined;
+
         if (
           cached &&
           cached.fileMtime === mtime &&
-          cached.indexedBytes === size
+          cached.indexedBytes === size &&
+          this.summaryCacheTokenMatches(cached, summaryCacheToken)
         ) {
           if (cached.isEmpty) continue;
           summaries.push({
@@ -742,19 +775,24 @@ export class SessionIndexService implements ISessionIndexService {
             model: cached.model,
           });
         } else {
-          cacheMisses.push({ sessionId, mtime, size });
+          cacheMisses.push({ sessionId, mtime, size, summaryCacheToken });
         }
       }
 
-      for (const { sessionId, mtime, size } of cacheMisses) {
+      for (const { sessionId, mtime, size, summaryCacheToken } of cacheMisses) {
         parseCalls += 1;
         const summary = await reader.getSessionSummary(sessionId, projectId);
         if (summary) {
+          const cacheToken =
+            summaryCacheToken !== undefined
+              ? summaryCacheToken
+              : await this.getSummaryCacheToken(reader, sessionId);
           summaries.push(summary);
           index.sessions[sessionId] = this.toCachedSummary(
             summary,
             mtime,
             size,
+            cacheToken,
           );
           indexChanged = true;
         } else {
@@ -991,11 +1029,16 @@ export class SessionIndexService implements ISessionIndexService {
       const stats = await fs.stat(filePath);
       const mtime = stats.mtimeMs;
       const size = stats.size;
+      const summaryCacheToken =
+        cached && cached.fileMtime === mtime && cached.indexedBytes === size
+          ? await this.getSummaryCacheToken(reader, sessionId)
+          : undefined;
 
       if (
         cached &&
         cached.fileMtime === mtime &&
-        cached.indexedBytes === size
+        cached.indexedBytes === size &&
+        this.summaryCacheTokenMatches(cached, summaryCacheToken)
       ) {
         if (cached.isEmpty) return null;
         return cached.title;
@@ -1003,7 +1046,16 @@ export class SessionIndexService implements ISessionIndexService {
 
       const summary = await reader.getSessionSummary(sessionId, projectId);
       if (summary) {
-        index.sessions[sessionId] = this.toCachedSummary(summary, mtime, size);
+        const cacheToken =
+          summaryCacheToken !== undefined
+            ? summaryCacheToken
+            : await this.getSummaryCacheToken(reader, sessionId);
+        index.sessions[sessionId] = this.toCachedSummary(
+          summary,
+          mtime,
+          size,
+          cacheToken,
+        );
         await this.saveIndex(sessionDir, reader);
         return summary.title;
       }

--- a/packages/server/src/routes/sessions.ts
+++ b/packages/server/src/routes/sessions.ts
@@ -95,6 +95,12 @@ function isCodexProviderName(
   return provider === "codex" || provider === "codex-oss";
 }
 
+function getMessageId(message: Message): string | undefined {
+  return (
+    message.uuid ?? (typeof message.id === "string" ? message.id : undefined)
+  );
+}
+
 export interface SessionsDeps {
   supervisor: Supervisor;
   scanner: ProjectScanner;
@@ -569,6 +575,8 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
         // 2. No active process (tools aren't potentially in progress)
         // When we own the session, tools without results might be pending approval
         includeOrphans: wasEverOwned && !process,
+        tailCompactions,
+        beforeMessageId,
       },
     );
 
@@ -592,7 +600,11 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
           sessionId,
           project.id,
           afterMessageId,
-          { includeOrphans: wasEverOwned && !process },
+          {
+            includeOrphans: wasEverOwned && !process,
+            tailCompactions,
+            beforeMessageId,
+          },
         );
       }
     }
@@ -618,7 +630,11 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
           sessionId,
           project.id,
           afterMessageId,
-          { includeOrphans: wasEverOwned && !process },
+          {
+            includeOrphans: wasEverOwned && !process,
+            tailCompactions,
+            beforeMessageId,
+          },
         );
       }
     }
@@ -728,7 +744,16 @@ export function createSessionsRoutes(deps: SessionsDeps): Hono {
     // tailCompactions slices to last N compact boundaries; skip when afterMessageId is
     // present since that's a different use case (incremental forward-fetch)
     let paginationInfo: PaginationInfo | undefined;
-    if (
+    if (loadedSession?.pagination && !afterMessageId) {
+      const firstMessage = session.messages[0];
+      paginationInfo = {
+        ...loadedSession.pagination,
+        returnedMessageCount: session.messages.length,
+        truncatedBeforeMessageId: firstMessage
+          ? getMessageId(firstMessage)
+          : undefined,
+      };
+    } else if (
       tailCompactions !== undefined &&
       !Number.isNaN(tailCompactions) &&
       tailCompactions > 0 &&

--- a/packages/server/src/sessions/codex-reader.ts
+++ b/packages/server/src/sessions/codex-reader.ts
@@ -11,8 +11,9 @@
  * Unlike Claude's DAG structure, Codex sessions are linear.
  */
 
+import type { Stats } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   type CodexEventMsgEntry,
   type CodexFunctionCallOutputPayload,
@@ -37,7 +38,12 @@ import type {
   Session,
   SessionSummary,
 } from "../supervisor/types.js";
-import { readFirstLine, readJsonlLines } from "../utils/jsonl.js";
+import {
+  readFirstLine,
+  readJsonlLines,
+  readJsonlTailLines,
+} from "../utils/jsonl.js";
+import type { PaginationInfo } from "./pagination.js";
 import type {
   GetSessionOptions,
   ISessionReader,
@@ -55,6 +61,11 @@ export interface CodexSessionReaderOptions {
    * Only sessions with this cwd will be listed.
    */
   projectPath?: string;
+  /**
+   * Codex app thread title index. Defaults to the sibling of sessionsDir:
+   * ~/.codex/session_index.jsonl. Set to null to disable.
+   */
+  sessionIndexPath?: string | null;
 }
 
 interface CodexSessionFile {
@@ -68,6 +79,32 @@ interface CodexSessionFile {
 }
 
 const CODEX_META_READ_MAX_BYTES = 1024 * 1024;
+const CODEX_COMPACT_BOUNDARY_LINE_RE =
+  /(^|[,{])\s*"type"\s*:\s*"(?:compacted|context_compacted)"/;
+
+interface CodexSummaryCacheEntry {
+  filePath: string;
+  mtime: number;
+  size: number;
+  threadIndexMtime: number | null;
+  threadIndexSize: number | null;
+  threadName: string | null;
+  summary: SessionSummary;
+  totalCompactions: number;
+}
+
+interface CodexThreadNameCache {
+  filePath: string;
+  mtime: number;
+  size: number;
+  names: Map<string, string>;
+}
+
+interface CodexThreadNameSnapshot {
+  title: string | null;
+  indexMtime: number | null;
+  indexSize: number | null;
+}
 
 /**
  * Codex-specific session reader for Codex CLI JSONL files.
@@ -78,14 +115,22 @@ const CODEX_META_READ_MAX_BYTES = 1024 * 1024;
 export class CodexSessionReader implements ISessionReader {
   private sessionsDir: string;
   private projectPath?: string;
+  private sessionIndexPath?: string;
 
   // Cache of session ID -> file path for quick lookups
   private sessionFileCache: Map<string, CodexSessionFile> = new Map();
+  private summaryCache: Map<string, CodexSummaryCacheEntry> = new Map();
+  private threadNameCache: CodexThreadNameCache | null = null;
   private cacheTimestamp = 0;
   private readonly CACHE_TTL_MS = 5000; // 5 second cache
 
   constructor(options: CodexSessionReaderOptions) {
     this.sessionsDir = options.sessionsDir;
+    this.sessionIndexPath =
+      options.sessionIndexPath === null
+        ? undefined
+        : (options.sessionIndexPath ??
+          join(dirname(options.sessionsDir), "session_index.jsonl"));
     this.projectPath = options.projectPath
       ? canonicalizeProjectPath(options.projectPath)
       : undefined;
@@ -93,6 +138,8 @@ export class CodexSessionReader implements ISessionReader {
 
   invalidateCache(): void {
     this.sessionFileCache.clear();
+    this.summaryCache.clear();
+    this.threadNameCache = null;
     this.cacheTimestamp = 0;
   }
 
@@ -132,6 +179,21 @@ export class CodexSessionReader implements ISessionReader {
     if (!sessionFile) return null;
 
     try {
+      const stats = await stat(sessionFile.filePath);
+      const threadName = await this.getCodexThreadName(sessionId);
+      const cached = this.summaryCache.get(sessionId);
+      if (
+        cached &&
+        cached.filePath === sessionFile.filePath &&
+        cached.mtime === stats.mtimeMs &&
+        cached.size === stats.size &&
+        cached.threadIndexMtime === threadName.indexMtime &&
+        cached.threadIndexSize === threadName.indexSize &&
+        cached.threadName === threadName.title
+      ) {
+        return cached.summary;
+      }
+
       const lines = await readJsonlLines(sessionFile.filePath);
       if (lines.length === 0 || (lines.length === 1 && !lines[0])) return null;
       const entries: CodexSessionEntry[] = [];
@@ -145,50 +207,27 @@ export class CodexSessionReader implements ISessionReader {
 
       if (entries.length === 0) return null;
 
-      // Extract session metadata from first entry
-      const metaEntry = entries.find((e) => e.type === "session_meta") as
-        | CodexSessionMetaEntry
-        | undefined;
-      if (!metaEntry) return null;
-
-      const stats = await stat(sessionFile.filePath);
-      const { title, fullTitle } = this.extractTitle(entries);
-      const messageCount = this.countMessages(entries);
-      const model = this.extractModel(entries);
-      const provider = this.determineProvider(metaEntry, model);
-      const turnContext = this.extractTurnContext(entries);
-      const contextUsage = this.extractContextUsage(entries, model, provider);
-
-      // Skip sessions with no actual conversation messages
-      if (messageCount === 0) return null;
-
-      return {
-        id: sessionId,
+      const summary = this.buildSummaryFromEntries(
+        sessionId,
         projectId,
-        title,
-        fullTitle,
-        createdAt: metaEntry.payload.timestamp,
-        updatedAt: stats.mtime.toISOString(),
-        messageCount,
-        ownership: { owner: "none" },
-        contextUsage,
-        provider,
-        model,
-        originator: metaEntry.payload.originator,
-        cliVersion: metaEntry.payload.cli_version,
-        source: metaEntry.payload.source,
-        approvalPolicy: turnContext?.payload.approval_policy,
-        sandboxPolicy: turnContext?.payload.sandbox_policy
-          ? {
-              type: turnContext.payload.sandbox_policy.type,
-              networkAccess: turnContext.payload.sandbox_policy.network_access,
-              excludeTmpdirEnvVar:
-                turnContext.payload.sandbox_policy.exclude_tmpdir_env_var,
-              excludeSlashTmp:
-                turnContext.payload.sandbox_policy.exclude_slash_tmp,
-            }
-          : undefined,
-      };
+        stats,
+        entries,
+        threadName.title,
+      );
+      if (!summary) return null;
+
+      this.summaryCache.set(sessionId, {
+        filePath: sessionFile.filePath,
+        mtime: stats.mtimeMs,
+        size: stats.size,
+        threadIndexMtime: threadName.indexMtime,
+        threadIndexSize: threadName.indexSize,
+        threadName: threadName.title,
+        summary,
+        totalCompactions: this.countCompactions(entries),
+      });
+
+      return summary;
     } catch {
       return null;
     }
@@ -198,7 +237,7 @@ export class CodexSessionReader implements ISessionReader {
     sessionId: string,
     projectId: UrlProjectId,
     afterMessageId?: string,
-    _options?: GetSessionOptions,
+    options?: GetSessionOptions,
   ): Promise<LoadedSession | null> {
     const summary = await this.getSessionSummary(sessionId, projectId);
     if (!summary) return null;
@@ -206,7 +245,19 @@ export class CodexSessionReader implements ISessionReader {
     const sessionFile = await this.findSessionFile(sessionId);
     if (!sessionFile) return null;
 
-    const lines = await readJsonlLines(sessionFile.filePath);
+    const canTailRead =
+      !afterMessageId &&
+      !options?.beforeMessageId &&
+      options?.tailCompactions !== undefined &&
+      options.tailCompactions > 0;
+    const tailRead = canTailRead
+      ? await readJsonlTailLines(sessionFile.filePath, {
+          boundaryCount: options.tailCompactions ?? 0,
+          isBoundaryLine: (line) => CODEX_COMPACT_BOUNDARY_LINE_RE.test(line),
+        })
+      : null;
+    const lines =
+      tailRead?.lines ?? (await readJsonlLines(sessionFile.filePath));
 
     const entries: CodexSessionEntry[] = [];
     for (const line of lines) {
@@ -225,14 +276,34 @@ export class CodexSessionReader implements ISessionReader {
       // Logic to filter entries would go here if strict incremental loading is needed
     }
 
+    const cachedSummary = this.summaryCache.get(sessionId);
+    const totalCompactions =
+      cachedSummary?.totalCompactions ?? this.countCompactions(entries);
+    const pagination: PaginationInfo | undefined = tailRead
+      ? {
+          hasOlderMessages:
+            tailRead.truncated ||
+            (options?.tailCompactions !== undefined &&
+              totalCompactions > options.tailCompactions),
+          totalMessageCount: summary.messageCount,
+          returnedMessageCount: this.countMessages(entries),
+          truncatedBeforeMessageId: undefined,
+          totalCompactions,
+        }
+      : undefined;
+
     return {
       summary,
       data: {
-        provider: this.determineProviderFromEntries(entries),
+        provider:
+          summary.provider === "codex" || summary.provider === "codex-oss"
+            ? summary.provider
+            : this.determineProviderFromEntries(entries),
         session: {
           entries: finalEntries,
         },
       },
+      pagination,
     };
   }
 
@@ -262,6 +333,11 @@ export class CodexSessionReader implements ISessionReader {
     } catch {
       return null;
     }
+  }
+
+  async getSummaryCacheToken(sessionId: string): Promise<string | null> {
+    const threadName = await this.getCodexThreadName(sessionId);
+    return threadName.title;
   }
 
   /**
@@ -428,6 +504,60 @@ export class CodexSessionReader implements ISessionReader {
     );
   }
 
+  private buildSummaryFromEntries(
+    sessionId: string,
+    projectId: UrlProjectId,
+    stats: Stats,
+    entries: CodexSessionEntry[],
+    codexThreadName: string | null,
+  ): SessionSummary | null {
+    // Extract session metadata from first entry
+    const metaEntry = entries.find((e) => e.type === "session_meta") as
+      | CodexSessionMetaEntry
+      | undefined;
+    if (!metaEntry) return null;
+
+    const extractedTitle = this.extractTitle(entries);
+    const title = codexThreadName ?? extractedTitle.title;
+    const fullTitle = codexThreadName ?? extractedTitle.fullTitle;
+    const messageCount = this.countMessages(entries);
+    const model = this.extractModel(entries);
+    const provider = this.determineProvider(metaEntry, model);
+    const turnContext = this.extractTurnContext(entries);
+    const contextUsage = this.extractContextUsage(entries, model, provider);
+
+    // Skip sessions with no actual conversation messages
+    if (messageCount === 0) return null;
+
+    return {
+      id: sessionId,
+      projectId,
+      title,
+      fullTitle,
+      createdAt: metaEntry.payload.timestamp,
+      updatedAt: stats.mtime.toISOString(),
+      messageCount,
+      ownership: { owner: "none" },
+      contextUsage,
+      provider,
+      model,
+      originator: metaEntry.payload.originator,
+      cliVersion: metaEntry.payload.cli_version,
+      source: metaEntry.payload.source,
+      approvalPolicy: turnContext?.payload.approval_policy,
+      sandboxPolicy: turnContext?.payload.sandbox_policy
+        ? {
+            type: turnContext.payload.sandbox_policy.type,
+            networkAccess: turnContext.payload.sandbox_policy.network_access,
+            excludeTmpdirEnvVar:
+              turnContext.payload.sandbox_policy.exclude_tmpdir_env_var,
+            excludeSlashTmp:
+              turnContext.payload.sandbox_policy.exclude_slash_tmp,
+          }
+        : undefined,
+    };
+  }
+
   /**
    * Extract title from entries (first user message).
    */
@@ -483,6 +613,62 @@ export class CodexSessionReader implements ISessionReader {
     return { title: null, fullTitle: null };
   }
 
+  private async getCodexThreadName(
+    sessionId: string,
+  ): Promise<CodexThreadNameSnapshot> {
+    if (!this.sessionIndexPath) {
+      return { title: null, indexMtime: null, indexSize: null };
+    }
+
+    try {
+      const stats = await stat(this.sessionIndexPath);
+      let cache = this.threadNameCache;
+      if (
+        !cache ||
+        cache.filePath !== this.sessionIndexPath ||
+        cache.mtime !== stats.mtimeMs ||
+        cache.size !== stats.size
+      ) {
+        const names = new Map<string, string>();
+        const lines = await readJsonlLines(this.sessionIndexPath);
+        for (const line of lines) {
+          try {
+            const record = JSON.parse(line) as {
+              id?: unknown;
+              thread_name?: unknown;
+            };
+            if (
+              typeof record.id === "string" &&
+              typeof record.thread_name === "string"
+            ) {
+              const threadName = record.thread_name.trim();
+              if (threadName) {
+                names.set(record.id, threadName);
+              }
+            }
+          } catch {
+            // Ignore corrupt index lines; session JSONL remains the fallback.
+          }
+        }
+        cache = {
+          filePath: this.sessionIndexPath,
+          mtime: stats.mtimeMs,
+          size: stats.size,
+          names,
+        };
+        this.threadNameCache = cache;
+      }
+
+      return {
+        title: cache.names.get(sessionId) ?? null,
+        indexMtime: stats.mtimeMs,
+        indexSize: stats.size,
+      };
+    } catch {
+      return { title: null, indexMtime: null, indexSize: null };
+    }
+  }
+
   private isSystemPromptUserMessage(text: string): boolean {
     const trimmed = text.trimStart();
     return (
@@ -520,6 +706,21 @@ export class CodexSessionReader implements ISessionReader {
       }
     }
 
+    return count;
+  }
+
+  private countCompactions(entries: CodexSessionEntry[]): number {
+    let count = 0;
+    for (const entry of entries) {
+      if (entry.type === "compacted") {
+        count++;
+      } else if (
+        entry.type === "event_msg" &&
+        entry.payload.type === "context_compacted"
+      ) {
+        count++;
+      }
+    }
     return count;
   }
 

--- a/packages/server/src/sessions/types.ts
+++ b/packages/server/src/sessions/types.ts
@@ -7,6 +7,7 @@
 
 import type { UnifiedSession, UrlProjectId } from "@yep-anywhere/shared";
 import type { Message, Session, SessionSummary } from "../supervisor/types.js";
+import type { PaginationInfo } from "./pagination.js";
 
 /**
  * Options for reading a session.
@@ -14,12 +15,17 @@ import type { Message, Session, SessionSummary } from "../supervisor/types.js";
 export interface GetSessionOptions {
   /** Include orphaned tool use detection (default: true, only applicable for Claude) */
   includeOrphans?: boolean;
+  /** Return only the last N compaction chunks when supported by the provider. */
+  tailCompactions?: number;
+  /** Cursor for loading older compacted chunks. */
+  beforeMessageId?: string;
 }
 
 // Return type that includes both the computed summary and the raw provider data
 export interface LoadedSession {
   summary: SessionSummary;
   data: UnifiedSession;
+  pagination?: PaginationInfo;
 }
 
 /**
@@ -72,6 +78,13 @@ export interface ISessionReader {
     cachedMtime: number,
     cachedSize: number,
   ): Promise<{ summary: SessionSummary; mtime: number; size: number } | null>;
+
+  /**
+   * Optional extra cache token for summary fields that come from files outside
+   * the primary session file, such as Codex's session_index.jsonl thread names.
+   * Return undefined by omitting the method when unsupported.
+   */
+  getSummaryCacheToken?(sessionId: string): Promise<string | null>;
 
   /**
    * Get mappings from tool use IDs to agent session IDs.

--- a/packages/server/src/utils/jsonl.ts
+++ b/packages/server/src/utils/jsonl.ts
@@ -61,3 +61,82 @@ export async function readJsonlLines(filePath: string): Promise<string[]> {
   const raw = await readFile(filePath, "utf-8");
   return stripBom(raw).trim().split("\n");
 }
+
+export interface ReadJsonlTailLinesOptions {
+  /** Number of boundary lines to include when reading from the end. */
+  boundaryCount: number;
+  /** Return true when a line is a logical boundary for the caller. */
+  isBoundaryLine: (line: string) => boolean;
+  /** Read chunk size for backward scanning. */
+  chunkSize?: number;
+}
+
+export interface ReadJsonlTailLinesResult {
+  lines: string[];
+  truncated: boolean;
+}
+
+/**
+ * Read a JSONL suffix from the end of a file, starting at the Nth boundary from
+ * the end. This avoids parsing the entire file for "show me the latest chunk"
+ * views of large session logs.
+ */
+export async function readJsonlTailLines(
+  filePath: string,
+  options: ReadJsonlTailLinesOptions,
+): Promise<ReadJsonlTailLinesResult> {
+  if (options.boundaryCount <= 0) {
+    return { lines: await readJsonlLines(filePath), truncated: false };
+  }
+
+  let fd: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    fd = await open(filePath, "r");
+    const stats = await fd.stat();
+    const chunkSize = options.chunkSize ?? 1024 * 1024;
+    let position = stats.size;
+    let content = Buffer.alloc(0);
+
+    while (position > 0) {
+      const readStart = Math.max(0, position - chunkSize);
+      const length = position - readStart;
+      const buf = Buffer.alloc(length);
+      const { bytesRead } = await fd.read(buf, 0, length, readStart);
+      if (bytesRead === 0) break;
+
+      content = Buffer.concat([buf.subarray(0, bytesRead), content]);
+      position = readStart;
+
+      const lines = stripBom(content.toString("utf-8"))
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      let seenBoundaries = 0;
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i];
+        if (!line || !options.isBoundaryLine(line)) continue;
+
+        seenBoundaries++;
+        if (seenBoundaries >= options.boundaryCount) {
+          return {
+            lines: lines.slice(i),
+            truncated: i > 0 || readStart > 0,
+          };
+        }
+      }
+    }
+
+    return {
+      lines: stripBom(content.toString("utf-8"))
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean),
+      truncated: false,
+    };
+  } catch {
+    return { lines: await readJsonlLines(filePath), truncated: false };
+  } finally {
+    await fd?.close();
+  }
+}

--- a/packages/server/test/indexes/SessionIndexService.test.ts
+++ b/packages/server/test/indexes/SessionIndexService.test.ts
@@ -170,6 +170,63 @@ describe("SessionIndexService", () => {
       );
       expect(sessions2[0]?.messageCount).toBe(2);
     });
+
+    it("re-parses when a reader summary cache token changes", async () => {
+      const externalSessionDir = join(testDir, "external-sessions");
+      await mkdir(externalSessionDir, { recursive: true });
+      const filePath = join(externalSessionDir, "session-1.jsonl");
+      await writeFile(filePath, "stable session file\n");
+
+      let externalTitle = "Codex generated title";
+      let parseCount = 0;
+      const tokenReader: ISessionReader = {
+        getIndexScopeKey: (sessionDir) => `codex::${sessionDir}::/tmp/project`,
+        listSessionFiles: async (sessionDir) => [
+          {
+            sessionId: "session-1",
+            filePath: join(sessionDir, "session-1.jsonl"),
+          },
+        ],
+        getSummaryCacheToken: async () => externalTitle,
+        getSessionSummary: async (
+          sessionId: string,
+          currentProjectId: string,
+        ): Promise<SessionSummary> => {
+          parseCount++;
+          const fileStats = await stat(filePath);
+          return {
+            id: sessionId,
+            projectId: currentProjectId,
+            title: externalTitle,
+            fullTitle: externalTitle,
+            createdAt: new Date(fileStats.mtimeMs).toISOString(),
+            updatedAt: new Date(fileStats.mtimeMs).toISOString(),
+            messageCount: 1,
+            ownership: { owner: "none" },
+            provider: "codex",
+          };
+        },
+        getAgentMappings: async () => [],
+        getAgentSession: async () => null,
+      };
+
+      const first = await service.getSessionsWithCache(
+        externalSessionDir,
+        projectId,
+        tokenReader,
+      );
+      expect(first[0]?.title).toBe("Codex generated title");
+
+      externalTitle = "Updated Codex title";
+      const second = await service.getSessionsWithCache(
+        externalSessionDir,
+        projectId,
+        tokenReader,
+      );
+
+      expect(second[0]?.title).toBe("Updated Codex title");
+      expect(parseCount).toBe(2);
+    });
   });
 
   describe("new files", () => {

--- a/packages/server/test/routes/session-detail-tail-options.test.ts
+++ b/packages/server/test/routes/session-detail-tail-options.test.ts
@@ -1,0 +1,96 @@
+import type { UrlProjectId } from "@yep-anywhere/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type SessionsDeps,
+  createSessionsRoutes,
+} from "../../src/routes/sessions.js";
+import type {
+  ISessionReader,
+  LoadedSession,
+} from "../../src/sessions/types.js";
+import type { Project, SessionSummary } from "../../src/supervisor/types.js";
+
+function createProject(): Project {
+  return {
+    id: "proj-1" as UrlProjectId,
+    path: "/tmp/project",
+    name: "project",
+    sessionCount: 1,
+    sessionDir: "/tmp/project/.claude-sessions",
+    activeOwnedCount: 0,
+    activeExternalCount: 0,
+    lastActivity: null,
+    provider: "claude",
+  };
+}
+
+function createSummary(): SessionSummary {
+  return {
+    id: "sess-1",
+    projectId: "proj-1" as UrlProjectId,
+    title: "Session",
+    fullTitle: "Session",
+    createdAt: "2026-03-10T09:45:00.000Z",
+    updatedAt: "2026-03-10T09:46:00.000Z",
+    messageCount: 1,
+    ownership: { owner: "none" },
+    provider: "claude",
+  };
+}
+
+function createLoadedSession(): LoadedSession {
+  const summary = createSummary();
+  return {
+    summary,
+    data: {
+      provider: "claude",
+      session: {
+        messages: [
+          {
+            type: "user",
+            uuid: "msg-1",
+            parentUuid: null,
+            cwd: "/tmp/project",
+            message: { role: "user", content: "hello" },
+          } as never,
+        ],
+      },
+    },
+  };
+}
+
+describe("Session detail tail options", () => {
+  it("passes tailCompactions to the session reader before route-level slicing", async () => {
+    const project = createProject();
+    const getSession = vi.fn(async () => createLoadedSession());
+    const reader = {
+      getSession,
+    } as unknown as ISessionReader;
+
+    const routes = createSessionsRoutes({
+      supervisor: {
+        getProcessForSession: vi.fn(() => null),
+        wasEverOwned: vi.fn(() => false),
+      } as unknown as SessionsDeps["supervisor"],
+      scanner: {
+        getOrCreateProject: vi.fn(async () => project),
+      } as unknown as SessionsDeps["scanner"],
+      readerFactory: vi.fn(() => reader),
+    });
+
+    const response = await routes.request(
+      `/projects/${project.id}/sessions/sess-1?tailCompactions=2`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(getSession).toHaveBeenCalledWith(
+      "sess-1",
+      project.id,
+      undefined,
+      expect.objectContaining({
+        includeOrphans: false,
+        tailCompactions: 2,
+      }),
+    );
+  });
+});

--- a/packages/server/test/sessions/codex-reader-oss.test.ts
+++ b/packages/server/test/sessions/codex-reader-oss.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { UrlProjectId } from "@yep-anywhere/shared";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { encodeProjectId } from "../../src/projects/paths.js";
 import { CodexSessionReader } from "../../src/sessions/codex-reader.js";
+import * as jsonlUtils from "../../src/utils/jsonl.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -331,5 +332,241 @@ describe("CodexSessionReader - OSS Support", () => {
       "test-project" as UrlProjectId,
     );
     expect(summary?.originator).toBe("yep-anywhere");
+  });
+
+  it("uses Codex session_index thread_name as the session title", async () => {
+    const sessionId = "indexed-title-session";
+    const sessionIndexPath = join(testDir, "session_index.jsonl");
+    reader = new CodexSessionReader({
+      sessionsDir: testDir,
+      sessionIndexPath,
+    });
+    await createSessionFile(sessionId, "openai", "gpt-5.3-codex");
+    await writeFile(
+      sessionIndexPath,
+      `${JSON.stringify({
+        id: sessionId,
+        thread_name: "优化会话切换加载",
+        updated_at: new Date().toISOString(),
+      })}\n`,
+    );
+
+    const summary = await reader.getSessionSummary(
+      sessionId,
+      "test-project" as UrlProjectId,
+    );
+
+    expect(summary?.title).toBe("优化会话切换加载");
+    expect(summary?.fullTitle).toBe("优化会话切换加载");
+  });
+
+  it("refreshes cached summaries when Codex session_index changes", async () => {
+    const sessionId = "indexed-title-refresh";
+    const sessionIndexPath = join(testDir, "session_index.jsonl");
+    reader = new CodexSessionReader({
+      sessionsDir: testDir,
+      sessionIndexPath,
+    });
+    await createSessionFile(sessionId, "openai", "gpt-5.3-codex");
+    await writeFile(
+      sessionIndexPath,
+      `${JSON.stringify({
+        id: sessionId,
+        thread_name: "Old title",
+        updated_at: new Date().toISOString(),
+      })}\n`,
+    );
+
+    const firstSummary = await reader.getSessionSummary(
+      sessionId,
+      "test-project" as UrlProjectId,
+    );
+    expect(firstSummary?.title).toBe("Old title");
+
+    await writeFile(
+      sessionIndexPath,
+      `${JSON.stringify({
+        id: sessionId,
+        thread_name: "Updated Codex generated title",
+        updated_at: new Date().toISOString(),
+      })}\n`,
+    );
+
+    const secondSummary = await reader.getSessionSummary(
+      sessionId,
+      "test-project" as UrlProjectId,
+    );
+    expect(secondSummary?.title).toBe("Updated Codex generated title");
+  });
+
+  it("returns only the compacted tail for tailCompactions detail loads", async () => {
+    const sessionId = "tail-compactions-detail";
+    const now = new Date().toISOString();
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: now,
+        payload: {
+          id: sessionId,
+          cwd: "/test/project",
+          timestamp: now,
+          model_provider: "ollama",
+        },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: now,
+        payload: {
+          cwd: "/test/project",
+          approval_policy: "never",
+          model: "qwen3-coder",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "old user message",
+        },
+      }),
+      JSON.stringify({
+        type: "compacted",
+        timestamp: now,
+        payload: { message: "first compaction" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "middle user message",
+        },
+      }),
+      JSON.stringify({
+        type: "compacted",
+        timestamp: now,
+        payload: { message: "second compaction" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "tail user message",
+        },
+      }),
+    ];
+
+    await writeFile(
+      join(testDir, `${sessionId}.jsonl`),
+      `${lines.join("\n")}\n`,
+    );
+
+    const loaded = await reader.getSession(
+      sessionId,
+      "test-project" as UrlProjectId,
+      undefined,
+      { tailCompactions: 1 } as never,
+    );
+
+    expect(loaded?.data.provider).toBe("codex-oss");
+    expect(loaded?.data.session.entries.map((entry) => entry.type)).toEqual([
+      "compacted",
+      "event_msg",
+    ]);
+    expect(loaded?.pagination).toMatchObject({
+      hasOlderMessages: true,
+      totalMessageCount: 3,
+      returnedMessageCount: 1,
+      totalCompactions: 2,
+    });
+  });
+
+  it("does not full-read a cached-summary session for tailCompactions detail loads", async () => {
+    const sessionId = "tail-compactions-no-detail-full-read";
+    const now = new Date().toISOString();
+    const lines = [
+      JSON.stringify({
+        type: "session_meta",
+        timestamp: now,
+        payload: {
+          id: sessionId,
+          cwd: "/test/project",
+          timestamp: now,
+          model_provider: "ollama",
+        },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        timestamp: now,
+        payload: {
+          cwd: "/test/project",
+          approval_policy: "never",
+          model: "qwen3-coder",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "old user message",
+        },
+      }),
+      JSON.stringify({
+        type: "compacted",
+        timestamp: now,
+        payload: { message: "first compaction" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "middle user message",
+        },
+      }),
+      JSON.stringify({
+        type: "compacted",
+        timestamp: now,
+        payload: { message: "second compaction" },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        timestamp: now,
+        payload: {
+          type: "user_message",
+          message: "tail user message",
+        },
+      }),
+    ];
+
+    await writeFile(
+      join(testDir, `${sessionId}.jsonl`),
+      `${lines.join("\n")}\n`,
+    );
+
+    await reader.getSessionSummary(sessionId, "test-project" as UrlProjectId);
+
+    const fullReadSpy = vi.spyOn(jsonlUtils, "readJsonlLines");
+    const tailReadSpy = vi.spyOn(jsonlUtils, "readJsonlTailLines");
+
+    const loaded = await reader.getSession(
+      sessionId,
+      "test-project" as UrlProjectId,
+      undefined,
+      { tailCompactions: 1 } as never,
+    );
+
+    expect(loaded?.data.session.entries.map((entry) => entry.type)).toEqual([
+      "compacted",
+      "event_msg",
+    ]);
+    expect(tailReadSpy).toHaveBeenCalledTimes(1);
+    expect(fullReadSpy).not.toHaveBeenCalled();
+
+    fullReadSpy.mockRestore();
+    tailReadSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Optimize remote/mobile session switching by reducing unnecessary full session detail reloads and reusing cached or in-flight session data.

## Changes

- Add a client-side session view cache for global session lists and session detail views.
- Reuse in-flight session detail requests so navigating away and back does not restart the same load.
- Load recent Codex session details from compact-boundary tail chunks for faster initial detail rendering.
- Add incremental older-message loading for compacted histories.
- Add server-side JSONL tail-read helpers and Codex reader support for compact-boundary pagination.

## Validation

- `pnpm --filter client test -- sessionViewCache.test.ts`
- `pnpm --filter server test -- SessionIndexService.test.ts session-detail-tail-options.test.ts codex-reader-oss.test.ts`
- `pnpm typecheck`
- `pnpm lint`

## Notes

This PR is scoped to remote session loading behavior. It intentionally excludes unrelated local work such as thinking/fast-mode UI, renderer styling, and model-setting changes.
