### PR TITLE
Improve session message UX and diff summaries

### DIFF
--- a/packages/client/src/api/upload.ts
+++ b/packages/client/src/api/upload.ts
@@ -282,3 +282,21 @@ export async function uploadFile(
 
   return uploadChunks(url, metadata, chunks, restOptions);
 }
+
+export function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith("image/");
+}
+
+export function getUploadUrl(filePath: string): string | null {
+  const parts = filePath.split("/");
+  if (parts.length < 3) return null;
+
+  const filename = parts[parts.length - 1];
+  const sessionId = parts[parts.length - 2];
+  const projectId = parts[parts.length - 3];
+
+  if (!filename || !sessionId || !projectId) return null;
+  if (!/^[0-9a-f-]{36}_/.test(filename)) return null;
+
+  return `/api/projects/${projectId}/sessions/${sessionId}/upload/${encodeURIComponent(filename)}`;
+}

--- a/packages/client/src/components/MessageInput.tsx
+++ b/packages/client/src/components/MessageInput.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { getUploadUrl, isImageMimeType } from "../api/upload";
 import { ENTER_SENDS_MESSAGE } from "../constants";
 import {
   type DraftControls,
@@ -376,26 +377,54 @@ export function MessageInput({
         {!collapsed &&
           (attachments.length > 0 || uploadProgress.length > 0) && (
             <div className="attachment-list">
-              {attachments.map((file) => (
-                <div key={file.id} className="attachment-chip">
-                  <span className="attachment-name" title={file.path}>
-                    {file.originalName}
-                  </span>
-                  <span className="attachment-size">
-                    {formatSize(file.size)}
-                  </span>
-                  <button
-                    type="button"
-                    className="attachment-remove"
-                    onClick={() => onRemoveAttachment?.(file.id)}
-                    aria-label={t("messageInputRemoveAttachment", {
-                      name: file.originalName,
-                    })}
+              {attachments.map((file) => {
+                const uploadUrl = isImageMimeType(file.mimeType)
+                  ? getUploadUrl(file.path)
+                  : null;
+                return (
+                  <div
+                    key={file.id}
+                    className={`attachment-chip ${uploadUrl ? "attachment-chip-image" : ""}`}
                   >
-                    x
-                  </button>
-                </div>
-              ))}
+                    {uploadUrl ? (
+                      <>
+                        <img
+                          src={uploadUrl}
+                          alt={file.originalName}
+                          className="attachment-image-preview"
+                        />
+                        <div className="attachment-image-meta">
+                          <span className="attachment-name" title={file.path}>
+                            {file.originalName}
+                          </span>
+                          <span className="attachment-size">
+                            {formatSize(file.size)}
+                          </span>
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <span className="attachment-name" title={file.path}>
+                          {file.originalName}
+                        </span>
+                        <span className="attachment-size">
+                          {formatSize(file.size)}
+                        </span>
+                      </>
+                    )}
+                    <button
+                      type="button"
+                      className="attachment-remove"
+                      onClick={() => onRemoveAttachment?.(file.id)}
+                      aria-label={t("messageInputRemoveAttachment", {
+                        name: file.originalName,
+                      })}
+                    >
+                      x
+                    </button>
+                  </div>
+                );
+              })}
               {uploadProgress.map((progress) => (
                 <div
                   key={progress.fileId}

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -154,6 +154,12 @@ function getOperationSegmentSummary(items: RenderItem[]): string {
     : `${total} operations · ${label}`;
 }
 
+export function hasPendingOperation(items: RenderItem[]): boolean {
+  return items.some(
+    (item) => item.type === "tool_call" && item.status === "pending",
+  );
+}
+
 function isTextItem(item: RenderItem): item is RenderItem & { type: "text" } {
   return item.type === "text";
 }
@@ -493,6 +499,7 @@ export const MessageList = memo(function MessageList({
       onToggle: (segmentId: string) => void,
     ) => {
       const summary = getOperationSegmentSummary(segment.items);
+      const isRunning = hasPendingOperation(segment.items);
 
       return (
         <div
@@ -501,7 +508,7 @@ export const MessageList = memo(function MessageList({
         >
           <button
             type="button"
-            className="operation-segment-toggle timeline-item"
+            className={`operation-segment-toggle timeline-item ${isRunning ? "running" : ""}`}
             onClick={() => onToggle(segment.id)}
             aria-expanded={expanded}
           >

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -158,7 +158,13 @@ function isTextItem(item: RenderItem): item is RenderItem & { type: "text" } {
   return item.type === "text";
 }
 
-function getTurnDurationMs(items: RenderItem[]): number | null {
+function isThinkingItem(
+  item: RenderItem,
+): item is RenderItem & { type: "thinking" } {
+  return item.type === "thinking";
+}
+
+function getLatestTimestampMs(items: RenderItem[]): number | null {
   const timestamps = items
     .flatMap((item) => item.sourceMessages)
     .map((msg) =>
@@ -169,22 +175,56 @@ function getTurnDurationMs(items: RenderItem[]): number | null {
     .filter((value) => Number.isFinite(value))
     .sort((a, b) => a - b);
 
-  if (timestamps.length < 2) {
-    return null;
-  }
-
-  const first = timestamps[0];
-  const last = timestamps[timestamps.length - 1];
-  if (first === undefined || last === undefined) {
-    return null;
-  }
-
-  return last > first ? last - first : null;
+  return timestamps.at(-1) ?? null;
 }
 
-function formatDurationLabel(durationMs: number | null): string {
-  if (!durationMs || durationMs < 1000) {
-    return "Worked for a moment";
+function getGroupStartedAt(group: TurnGroup | undefined): string | null {
+  if (!group?.isUserPrompt) {
+    return null;
+  }
+
+  const timestamp = group.items
+    .flatMap((item) => item.sourceMessages)
+    .map((msg) => msg.timestamp)
+    .find((value): value is string => typeof value === "string");
+
+  return timestamp ?? null;
+}
+
+function getEarliestTimestampMs(items: RenderItem[]): number | null {
+  const timestamps = items
+    .flatMap((item) => item.sourceMessages)
+    .map((msg) =>
+      typeof msg.timestamp === "string"
+        ? Date.parse(msg.timestamp)
+        : Number.NaN,
+    )
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b);
+
+  return timestamps[0] ?? null;
+}
+
+function getDurationFromTurnStart(
+  turnStartedAt: string | null | undefined,
+  endTimeMs: number | null,
+): number | null {
+  const startMs =
+    typeof turnStartedAt === "string" ? Date.parse(turnStartedAt) : Number.NaN;
+  if (!Number.isFinite(startMs) || endTimeMs === null) {
+    return null;
+  }
+  return Math.max(0, endTimeMs - startMs);
+}
+
+function formatDurationLabel(
+  durationMs: number | null,
+  verb: "worked" | "working",
+): string {
+  const prefix = verb === "working" ? "Working for" : "Worked for";
+
+  if (durationMs === null) {
+    return `${prefix} 0s`;
   }
 
   const totalSeconds = Math.round(durationMs / 1000);
@@ -192,19 +232,35 @@ function formatDurationLabel(durationMs: number | null): string {
   const seconds = totalSeconds % 60;
 
   if (minutes <= 0) {
-    return `Worked for ${seconds}s`;
+    return `${prefix} ${seconds}s`;
   }
 
   if (seconds === 0) {
-    return `Worked for ${minutes}m`;
+    return `${prefix} ${minutes}m`;
   }
 
-  return `Worked for ${minutes}m ${seconds}s`;
+  return `${prefix} ${minutes}m ${seconds}s`;
+}
+
+export function getDisplayAssistantTurnItems(items: RenderItem[]): RenderItem[] {
+  return items.filter((item) => !isThinkingItem(item));
+}
+
+export function getStreamingTurnSummary(
+  nowMs: number,
+  turnStartedAt?: string | null,
+): string | null {
+  const durationMs = getDurationFromTurnStart(turnStartedAt, nowMs);
+  return durationMs === null
+    ? null
+    : formatDurationLabel(durationMs, "working");
 }
 
 export function buildAssistantTurnRenderSegments(
   items: RenderItem[],
   isTurnStreaming: boolean,
+  durationItems: RenderItem[] = items,
+  turnStartedAt?: string | null,
 ): AssistantTurnRenderSegment[] {
   if (isTurnStreaming) {
     return groupAssistantTurnSegments(items);
@@ -219,13 +275,18 @@ export function buildAssistantTurnRenderSegments(
   if (collapsedItems.length === 0) {
     return groupAssistantTurnSegments(items);
   }
-
-  const durationMs = getTurnDurationMs(items);
+  const endTimeMs = getLatestTimestampMs(durationItems);
+  const startTimeMs = getEarliestTimestampMs(durationItems);
+  const durationMs =
+    getDurationFromTurnStart(turnStartedAt, endTimeMs) ??
+    (startTimeMs !== null && endTimeMs !== null
+      ? Math.max(0, endTimeMs - startTimeMs)
+      : null);
   return [
     {
       kind: "folded_reasoning",
       id: `reasoning-${items[0]?.id ?? "turn"}-${lastItem.id}`,
-      summary: formatDurationLabel(durationMs),
+      summary: formatDurationLabel(durationMs, "worked"),
       collapsedItems,
       visibleItems: [lastItem],
     },
@@ -252,6 +313,7 @@ interface Props {
   provider?: string;
   isStreaming?: boolean;
   isProcessing?: boolean;
+  turnStartedAt?: string | null;
   /** True when context is being compressed */
   isCompacting?: boolean;
   /** Increment this to force scroll to bottom (e.g., when user sends a message) */
@@ -286,6 +348,7 @@ export const MessageList = memo(function MessageList({
   provider,
   isStreaming = false,
   isProcessing = false,
+  turnStartedAt = null,
   isCompacting = false,
   scrollTrigger = 0,
   pendingMessages = [],
@@ -297,6 +360,7 @@ export const MessageList = memo(function MessageList({
   loadingOlder = false,
   onLoadOlderMessages,
 }: Props) {
+  const isActiveTurn = isStreaming || isProcessing;
   const containerRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const isInitialLoadRef = useRef(true);
@@ -310,6 +374,7 @@ export const MessageList = memo(function MessageList({
   const [expandedReasoningSegments, setExpandedReasoningSegments] = useState<
     Record<string, boolean>
   >({});
+  const [currentTimeMs, setCurrentTimeMs] = useState(() => Date.now());
 
   // Scroll to bottom, marking it as programmatic so scroll handler ignores it
   const scrollToBottom = useCallback((container: HTMLElement) => {
@@ -360,6 +425,17 @@ export const MessageList = memo(function MessageList({
     }
     return -1;
   }, [turnGroups]);
+  const hasStreamingAssistantOutput = useMemo(() => {
+    const lastGroup = turnGroups[turnGroups.length - 1];
+    return Boolean(isActiveTurn && lastGroup && !lastGroup.isUserPrompt);
+  }, [isActiveTurn, turnGroups]);
+  const streamingFallbackSummary = useMemo(() => {
+    if (!isActiveTurn || hasStreamingAssistantOutput) {
+      return null;
+    }
+
+    return getStreamingTurnSummary(currentTimeMs, turnStartedAt);
+  }, [isActiveTurn, hasStreamingAssistantOutput, currentTimeMs, turnStartedAt]);
 
   const toggleThinkingExpanded = useCallback(() => {
     setThinkingExpanded((prev) => !prev);
@@ -378,6 +454,21 @@ export const MessageList = memo(function MessageList({
       [segmentId]: !prev[segmentId],
     }));
   }, []);
+
+  useEffect(() => {
+    if (!isActiveTurn) {
+      return;
+    }
+
+    setCurrentTimeMs(Date.now());
+    const intervalId = window.setInterval(() => {
+      setCurrentTimeMs(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [isActiveTurn]);
 
   const renderItemsSegment = useCallback(
     (items: RenderItem[], context: SegmentRenderContext) =>
@@ -580,13 +671,28 @@ export const MessageList = memo(function MessageList({
         const firstItem = group.items[0];
         if (!firstItem) return null;
         const isCurrentStreamingTurn =
-          isStreaming && groupIndex === lastAssistantGroupIndex;
+          hasStreamingAssistantOutput && groupIndex === lastAssistantGroupIndex;
+        const completedTurnStartedAt =
+          groupIndex > 0 ? getGroupStartedAt(turnGroups[groupIndex - 1]) : null;
+        const displayItems = getDisplayAssistantTurnItems(group.items);
+        const streamingSummary = isCurrentStreamingTurn
+          ? getStreamingTurnSummary(currentTimeMs, turnStartedAt)
+          : null;
         const segments = buildAssistantTurnRenderSegments(
-          group.items,
+          displayItems,
           isCurrentStreamingTurn,
+          group.items,
+          isCurrentStreamingTurn ? turnStartedAt : completedTurnStartedAt,
         );
         return (
           <div key={`turn-${firstItem.id}`} className="assistant-turn">
+            {streamingSummary && (
+              <div className="reasoning-progress timeline-item">
+                <span className="reasoning-segment-label">
+                  {streamingSummary}
+                </span>
+              </div>
+            )}
             {segments.map((segment) => {
               const renderContext: SegmentRenderContext = {
                 isStreaming,
@@ -666,6 +772,15 @@ export const MessageList = memo(function MessageList({
           </div>
         );
       })}
+      {streamingFallbackSummary && (
+        <div className="assistant-turn assistant-turn-placeholder">
+          <div className="reasoning-progress timeline-item">
+            <span className="reasoning-segment-label">
+              {streamingFallbackSummary}
+            </span>
+          </div>
+        </div>
+      )}
       {/* Pending messages - shown as "Uploading..." or "Sending..." until server confirms */}
       {pendingMessages.map((pending) => (
         <div key={pending.tempId} className="pending-message">

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -8,6 +8,7 @@ import type { Message } from "../types";
 import type { RenderItem } from "../types/renderItems";
 import { ProcessingIndicator } from "./ProcessingIndicator";
 import { RenderItemComponent } from "./RenderItemComponent";
+import { TurnDiffSummary } from "./TurnDiffSummary";
 
 interface AssistantTurnGroup {
   isUserPrompt: false;
@@ -38,9 +39,7 @@ type AssistantTurnSegment = OperationSegment | ItemSegment;
  * Groups consecutive assistant items (text, thinking, tool_call) into turns.
  * User prompts break the grouping and are returned as separate groups.
  */
-function groupItemsIntoTurns(
-  items: RenderItem[],
-): TurnGroup[] {
+function groupItemsIntoTurns(items: RenderItem[]): TurnGroup[] {
   const groups: TurnGroup[] = [];
   let currentAssistantGroup: RenderItem[] = [];
 
@@ -255,6 +254,14 @@ export const MessageList = memo(function MessageList({
     () => groupItemsIntoTurns(renderItems),
     [renderItems],
   );
+  const lastAssistantGroupIndex = useMemo(() => {
+    for (let i = turnGroups.length - 1; i >= 0; i -= 1) {
+      if (!turnGroups[i]?.isUserPrompt) {
+        return i;
+      }
+    }
+    return -1;
+  }, [turnGroups]);
 
   const toggleThinkingExpanded = useCallback(() => {
     setThinkingExpanded((prev) => !prev);
@@ -397,7 +404,7 @@ export const MessageList = memo(function MessageList({
           </button>
         </div>
       )}
-      {turnGroups.map((group) => {
+      {turnGroups.map((group, groupIndex) => {
         if (group.isUserPrompt) {
           // User prompts render directly without timeline wrapper
           const item = group.items[0];
@@ -448,7 +455,10 @@ export const MessageList = memo(function MessageList({
                     aria-expanded={expanded}
                   >
                     <span className="operation-segment-label">{summary}</span>
-                    <span className="operation-segment-chevron" aria-hidden="true">
+                    <span
+                      className="operation-segment-chevron"
+                      aria-hidden="true"
+                    >
                       {expanded ? "▾" : "▸"}
                     </span>
                   </button>
@@ -469,6 +479,9 @@ export const MessageList = memo(function MessageList({
                 </div>
               );
             })}
+            {(!isStreaming || groupIndex !== lastAssistantGroupIndex) && (
+              <TurnDiffSummary items={group.items} />
+            )}
           </div>
         );
       })}

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -35,6 +35,16 @@ interface ItemSegment {
 
 type AssistantTurnSegment = OperationSegment | ItemSegment;
 
+interface FoldedReasoningSegment {
+  kind: "folded_reasoning";
+  id: string;
+  summary: string;
+  collapsedItems: RenderItem[];
+  visibleItems: RenderItem[];
+}
+
+type AssistantTurnRenderSegment = AssistantTurnSegment | FoldedReasoningSegment;
+
 /**
  * Groups consecutive assistant items (text, thinking, tool_call) into turns.
  * User prompts break the grouping and are returned as separate groups.
@@ -144,6 +154,84 @@ function getOperationSegmentSummary(items: RenderItem[]): string {
     : `${total} operations · ${label}`;
 }
 
+function isTextItem(item: RenderItem): item is RenderItem & { type: "text" } {
+  return item.type === "text";
+}
+
+function getTurnDurationMs(items: RenderItem[]): number | null {
+  const timestamps = items
+    .flatMap((item) => item.sourceMessages)
+    .map((msg) =>
+      typeof msg.timestamp === "string"
+        ? Date.parse(msg.timestamp)
+        : Number.NaN,
+    )
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b);
+
+  if (timestamps.length < 2) {
+    return null;
+  }
+
+  const first = timestamps[0];
+  const last = timestamps[timestamps.length - 1];
+  if (first === undefined || last === undefined) {
+    return null;
+  }
+
+  return last > first ? last - first : null;
+}
+
+function formatDurationLabel(durationMs: number | null): string {
+  if (!durationMs || durationMs < 1000) {
+    return "Worked for a moment";
+  }
+
+  const totalSeconds = Math.round(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes <= 0) {
+    return `Worked for ${seconds}s`;
+  }
+
+  if (seconds === 0) {
+    return `Worked for ${minutes}m`;
+  }
+
+  return `Worked for ${minutes}m ${seconds}s`;
+}
+
+export function buildAssistantTurnRenderSegments(
+  items: RenderItem[],
+  isTurnStreaming: boolean,
+): AssistantTurnRenderSegment[] {
+  if (isTurnStreaming) {
+    return groupAssistantTurnSegments(items);
+  }
+
+  const lastItem = items[items.length - 1];
+  if (!lastItem || !isTextItem(lastItem) || items.length < 2) {
+    return groupAssistantTurnSegments(items);
+  }
+
+  const collapsedItems = items.slice(0, -1);
+  if (collapsedItems.length === 0) {
+    return groupAssistantTurnSegments(items);
+  }
+
+  const durationMs = getTurnDurationMs(items);
+  return [
+    {
+      kind: "folded_reasoning",
+      id: `reasoning-${items[0]?.id ?? "turn"}-${lastItem.id}`,
+      summary: formatDurationLabel(durationMs),
+      collapsedItems,
+      visibleItems: [lastItem],
+    },
+  ];
+}
+
 /** Pending message waiting for server confirmation */
 interface PendingMessage {
   tempId: string;
@@ -186,6 +274,13 @@ interface Props {
   onLoadOlderMessages?: () => void;
 }
 
+interface SegmentRenderContext {
+  isStreaming: boolean;
+  provider?: string;
+  thinkingExpanded: boolean;
+  toggleThinkingExpanded: () => void;
+}
+
 export const MessageList = memo(function MessageList({
   messages,
   provider,
@@ -210,6 +305,9 @@ export const MessageList = memo(function MessageList({
   const followUpScrollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [thinkingExpanded, setThinkingExpanded] = useState(false);
   const [expandedOperationSegments, setExpandedOperationSegments] = useState<
+    Record<string, boolean>
+  >({});
+  const [expandedReasoningSegments, setExpandedReasoningSegments] = useState<
     Record<string, boolean>
   >({});
 
@@ -273,6 +371,64 @@ export const MessageList = memo(function MessageList({
       [segmentId]: !prev[segmentId],
     }));
   }, []);
+
+  const toggleReasoningSegment = useCallback((segmentId: string) => {
+    setExpandedReasoningSegments((prev) => ({
+      ...prev,
+      [segmentId]: !prev[segmentId],
+    }));
+  }, []);
+
+  const renderItemsSegment = useCallback(
+    (items: RenderItem[], context: SegmentRenderContext) =>
+      items.map((item) => (
+        <RenderItemComponent
+          key={item.id}
+          item={item}
+          isStreaming={context.isStreaming}
+          thinkingExpanded={context.thinkingExpanded}
+          toggleThinkingExpanded={context.toggleThinkingExpanded}
+          sessionProvider={context.provider}
+        />
+      )),
+    [],
+  );
+
+  const renderOperationSegment = useCallback(
+    (
+      segment: OperationSegment,
+      context: SegmentRenderContext,
+      expanded: boolean,
+      onToggle: (segmentId: string) => void,
+    ) => {
+      const summary = getOperationSegmentSummary(segment.items);
+
+      return (
+        <div
+          key={segment.id}
+          className={`operation-segment ${expanded ? "expanded" : "collapsed"}`}
+        >
+          <button
+            type="button"
+            className="operation-segment-toggle timeline-item"
+            onClick={() => onToggle(segment.id)}
+            aria-expanded={expanded}
+          >
+            <span className="operation-segment-label">{summary}</span>
+            <span className="operation-segment-chevron" aria-hidden="true">
+              {expanded ? "▾" : "▸"}
+            </span>
+          </button>
+          {expanded && (
+            <div className="operation-segment-content">
+              {renderItemsSegment(segment.items, context)}
+            </div>
+          )}
+        </div>
+      );
+    },
+    [renderItemsSegment],
+  );
 
   // Load older messages with scroll position preservation
   const handleLoadOlder = useCallback(() => {
@@ -423,60 +579,85 @@ export const MessageList = memo(function MessageList({
         // Assistant items wrapped in timeline container - key based on first item
         const firstItem = group.items[0];
         if (!firstItem) return null;
-        const segments = groupAssistantTurnSegments(group.items);
+        const isCurrentStreamingTurn =
+          isStreaming && groupIndex === lastAssistantGroupIndex;
+        const segments = buildAssistantTurnRenderSegments(
+          group.items,
+          isCurrentStreamingTurn,
+        );
         return (
           <div key={`turn-${firstItem.id}`} className="assistant-turn">
             {segments.map((segment) => {
+              const renderContext: SegmentRenderContext = {
+                isStreaming,
+                provider,
+                thinkingExpanded,
+                toggleThinkingExpanded,
+              };
+
+              if (segment.kind === "folded_reasoning") {
+                const expanded = expandedReasoningSegments[segment.id] ?? false;
+
+                return (
+                  <div
+                    key={segment.id}
+                    className={`reasoning-segment ${expanded ? "expanded" : "collapsed"}`}
+                  >
+                    <button
+                      type="button"
+                      className="reasoning-segment-toggle timeline-item"
+                      onClick={() => toggleReasoningSegment(segment.id)}
+                      aria-expanded={expanded}
+                    >
+                      <span className="reasoning-segment-label">
+                        {segment.summary}
+                      </span>
+                      <span
+                        className="reasoning-segment-chevron"
+                        aria-hidden="true"
+                      >
+                        {expanded ? "▾" : "▸"}
+                      </span>
+                    </button>
+                    {expanded && (
+                      <div className="reasoning-segment-content">
+                        {groupAssistantTurnSegments(segment.collapsedItems).map(
+                          (collapsedSegment) => {
+                            if (collapsedSegment.kind === "items") {
+                              return renderItemsSegment(
+                                collapsedSegment.items,
+                                renderContext,
+                              );
+                            }
+
+                            const operationExpanded =
+                              expandedOperationSegments[collapsedSegment.id] ??
+                              false;
+                            return renderOperationSegment(
+                              collapsedSegment,
+                              renderContext,
+                              operationExpanded,
+                              toggleOperationSegment,
+                            );
+                          },
+                        )}
+                      </div>
+                    )}
+                    {renderItemsSegment(segment.visibleItems, renderContext)}
+                  </div>
+                );
+              }
+
               if (segment.kind === "items") {
-                return segment.items.map((item) => (
-                  <RenderItemComponent
-                    key={item.id}
-                    item={item}
-                    isStreaming={isStreaming}
-                    thinkingExpanded={thinkingExpanded}
-                    toggleThinkingExpanded={toggleThinkingExpanded}
-                    sessionProvider={provider}
-                  />
-                ));
+                return renderItemsSegment(segment.items, renderContext);
               }
 
               const expanded = expandedOperationSegments[segment.id] ?? false;
-              const summary = getOperationSegmentSummary(segment.items);
-
-              return (
-                <div
-                  key={segment.id}
-                  className={`operation-segment ${expanded ? "expanded" : "collapsed"}`}
-                >
-                  <button
-                    type="button"
-                    className="operation-segment-toggle timeline-item"
-                    onClick={() => toggleOperationSegment(segment.id)}
-                    aria-expanded={expanded}
-                  >
-                    <span className="operation-segment-label">{summary}</span>
-                    <span
-                      className="operation-segment-chevron"
-                      aria-hidden="true"
-                    >
-                      {expanded ? "▾" : "▸"}
-                    </span>
-                  </button>
-                  {expanded && (
-                    <div className="operation-segment-content">
-                      {segment.items.map((item) => (
-                        <RenderItemComponent
-                          key={item.id}
-                          item={item}
-                          isStreaming={isStreaming}
-                          thinkingExpanded={thinkingExpanded}
-                          toggleThinkingExpanded={toggleThinkingExpanded}
-                          sessionProvider={provider}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </div>
+              return renderOperationSegment(
+                segment,
+                renderContext,
+                expanded,
+                toggleOperationSegment,
               );
             })}
             {(!isStreaming || groupIndex !== lastAssistantGroupIndex) && (

--- a/packages/client/src/components/MessageList.tsx
+++ b/packages/client/src/components/MessageList.tsx
@@ -9,14 +9,39 @@ import type { RenderItem } from "../types/renderItems";
 import { ProcessingIndicator } from "./ProcessingIndicator";
 import { RenderItemComponent } from "./RenderItemComponent";
 
+interface AssistantTurnGroup {
+  isUserPrompt: false;
+  items: RenderItem[];
+}
+
+interface UserPromptGroup {
+  isUserPrompt: true;
+  items: RenderItem[];
+}
+
+type TurnGroup = AssistantTurnGroup | UserPromptGroup;
+
+interface OperationSegment {
+  kind: "operations";
+  id: string;
+  items: RenderItem[];
+}
+
+interface ItemSegment {
+  kind: "items";
+  items: RenderItem[];
+}
+
+type AssistantTurnSegment = OperationSegment | ItemSegment;
+
 /**
  * Groups consecutive assistant items (text, thinking, tool_call) into turns.
  * User prompts break the grouping and are returned as separate groups.
  */
 function groupItemsIntoTurns(
   items: RenderItem[],
-): Array<{ isUserPrompt: boolean; items: RenderItem[] }> {
-  const groups: Array<{ isUserPrompt: boolean; items: RenderItem[] }> = [];
+): TurnGroup[] {
+  const groups: TurnGroup[] = [];
   let currentAssistantGroup: RenderItem[] = [];
 
   for (const item of items) {
@@ -40,6 +65,84 @@ function groupItemsIntoTurns(
   }
 
   return groups;
+}
+
+function isIntermediateOperationItem(item: RenderItem): boolean {
+  return item.type === "tool_call";
+}
+
+export function groupAssistantTurnSegments(
+  items: RenderItem[],
+): AssistantTurnSegment[] {
+  const segments: AssistantTurnSegment[] = [];
+  let currentItems: RenderItem[] = [];
+  let operationRun: RenderItem[] = [];
+
+  const flushCurrentItems = () => {
+    if (currentItems.length > 0) {
+      segments.push({ kind: "items", items: currentItems });
+      currentItems = [];
+    }
+  };
+
+  const flushOperationRun = () => {
+    if (operationRun.length === 0) {
+      return;
+    }
+
+    const first = operationRun[0];
+    const last = operationRun[operationRun.length - 1];
+    if (first && last) {
+      flushCurrentItems();
+      segments.push({
+        kind: "operations",
+        id: `ops-${first.id}-${last.id}`,
+        items: operationRun,
+      });
+    }
+
+    operationRun = [];
+  };
+
+  for (const item of items) {
+    if (isIntermediateOperationItem(item)) {
+      operationRun.push(item);
+      continue;
+    }
+
+    flushOperationRun();
+    currentItems.push(item);
+  }
+
+  flushOperationRun();
+  flushCurrentItems();
+
+  return segments;
+}
+
+function getOperationSegmentSummary(items: RenderItem[]): string {
+  const toolCalls = items.filter((item) => item.type === "tool_call");
+  const total = toolCalls.length;
+  const pending = toolCalls.filter((item) => item.status === "pending").length;
+  const errors = toolCalls.filter((item) => item.status === "error").length;
+  const aborted = toolCalls.filter((item) => item.status === "aborted").length;
+
+  const toolNames = Array.from(
+    new Set(toolCalls.map((item) => item.toolName).filter(Boolean)),
+  );
+  const label =
+    toolNames.length > 0
+      ? toolNames.slice(0, 3).join(" · ")
+      : "Intermediate operations";
+
+  const suffix: string[] = [];
+  if (pending > 0) suffix.push(`${pending} running`);
+  if (errors > 0) suffix.push(`${errors} failed`);
+  if (aborted > 0) suffix.push(`${aborted} interrupted`);
+
+  return suffix.length > 0
+    ? `${total} operations · ${label} · ${suffix.join(" · ")}`
+    : `${total} operations · ${label}`;
 }
 
 /** Pending message waiting for server confirmation */
@@ -107,6 +210,9 @@ export const MessageList = memo(function MessageList({
   const lastHeightRef = useRef(0);
   const followUpScrollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [thinkingExpanded, setThinkingExpanded] = useState(false);
+  const [expandedOperationSegments, setExpandedOperationSegments] = useState<
+    Record<string, boolean>
+  >({});
 
   // Scroll to bottom, marking it as programmatic so scroll handler ignores it
   const scrollToBottom = useCallback((container: HTMLElement) => {
@@ -152,6 +258,13 @@ export const MessageList = memo(function MessageList({
 
   const toggleThinkingExpanded = useCallback(() => {
     setThinkingExpanded((prev) => !prev);
+  }, []);
+
+  const toggleOperationSegment = useCallback((segmentId: string) => {
+    setExpandedOperationSegments((prev) => ({
+      ...prev,
+      [segmentId]: !prev[segmentId],
+    }));
   }, []);
 
   // Load older messages with scroll position preservation
@@ -303,18 +416,59 @@ export const MessageList = memo(function MessageList({
         // Assistant items wrapped in timeline container - key based on first item
         const firstItem = group.items[0];
         if (!firstItem) return null;
+        const segments = groupAssistantTurnSegments(group.items);
         return (
           <div key={`turn-${firstItem.id}`} className="assistant-turn">
-            {group.items.map((item) => (
-              <RenderItemComponent
-                key={item.id}
-                item={item}
-                isStreaming={isStreaming}
-                thinkingExpanded={thinkingExpanded}
-                toggleThinkingExpanded={toggleThinkingExpanded}
-                sessionProvider={provider}
-              />
-            ))}
+            {segments.map((segment) => {
+              if (segment.kind === "items") {
+                return segment.items.map((item) => (
+                  <RenderItemComponent
+                    key={item.id}
+                    item={item}
+                    isStreaming={isStreaming}
+                    thinkingExpanded={thinkingExpanded}
+                    toggleThinkingExpanded={toggleThinkingExpanded}
+                    sessionProvider={provider}
+                  />
+                ));
+              }
+
+              const expanded = expandedOperationSegments[segment.id] ?? false;
+              const summary = getOperationSegmentSummary(segment.items);
+
+              return (
+                <div
+                  key={segment.id}
+                  className={`operation-segment ${expanded ? "expanded" : "collapsed"}`}
+                >
+                  <button
+                    type="button"
+                    className="operation-segment-toggle timeline-item"
+                    onClick={() => toggleOperationSegment(segment.id)}
+                    aria-expanded={expanded}
+                  >
+                    <span className="operation-segment-label">{summary}</span>
+                    <span className="operation-segment-chevron" aria-hidden="true">
+                      {expanded ? "▾" : "▸"}
+                    </span>
+                  </button>
+                  {expanded && (
+                    <div className="operation-segment-content">
+                      {segment.items.map((item) => (
+                        <RenderItemComponent
+                          key={item.id}
+                          item={item}
+                          isStreaming={isStreaming}
+                          thinkingExpanded={thinkingExpanded}
+                          toggleThinkingExpanded={toggleThinkingExpanded}
+                          sessionProvider={provider}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         );
       })}

--- a/packages/client/src/components/ProviderBadge.tsx
+++ b/packages/client/src/components/ProviderBadge.tsx
@@ -46,6 +46,21 @@ export function ProviderBadge({
   const color = PROVIDER_COLORS[provider];
   const label = PROVIDER_LABELS[provider];
 
+  const formatGenericModelName = (value: string): string =>
+    value
+      .trim()
+      .split("-")
+      .map((part) => {
+        const lower = part.toLowerCase();
+        if (lower === "gpt") return "GPT";
+        if (lower === "codex") return "Codex";
+        if (lower === "mini") return "Mini";
+        if (lower === "max") return "Max";
+        if (lower.length === 0) return "";
+        return lower.charAt(0).toUpperCase() + lower.slice(1);
+      })
+      .join("-");
+
   // Format model name for display
   const getModelLabel = (modelName: string | undefined): string | null => {
     if (!modelName) return null;
@@ -75,9 +90,8 @@ export function ProviderBadge({
       return isExtendedContext ? `${capitalized} 1M` : capitalized;
     }
 
-    // For other models, capitalize first letter
-    const capitalized = modelName.charAt(0).toUpperCase() + modelName.slice(1);
-    return isExtendedContext ? `${capitalized} 1M` : capitalized;
+    const formatted = formatGenericModelName(modelName);
+    return isExtendedContext ? `${formatted} 1M` : formatted;
   };
 
   const modelLabel = getModelLabel(model);

--- a/packages/client/src/components/SessionListItem.tsx
+++ b/packages/client/src/components/SessionListItem.tsx
@@ -65,6 +65,10 @@ interface SessionListItemProps {
 
   /** Number of messages in session (0 indicates brand new session) */
   messageCount?: number;
+
+  /** Optional event handlers/classes for the root list item */
+  itemClassName?: string;
+  itemProps?: React.LiHTMLAttributes<HTMLLIElement>;
 }
 
 /**
@@ -123,6 +127,8 @@ export function SessionListItem({
   basePath = "",
   // New session detection
   messageCount,
+  itemClassName,
+  itemProps,
 }: SessionListItemProps) {
   const navigate = useNavigate();
 
@@ -314,6 +320,7 @@ export function SessionListItem({
     hasUnread && "unread",
     isSelected && "selected",
     isArchived && "archived",
+    itemClassName,
   ]
     .filter(Boolean)
     .join(" ");
@@ -338,7 +345,7 @@ export function SessionListItem({
   );
 
   return (
-    <li className={liClasses}>
+    <li className={liClasses} {...itemProps}>
       {/* Checkbox for multi-select (only shown when onSelect is provided) */}
       {onSelect && (
         <input

--- a/packages/client/src/components/TurnDiffSummary.tsx
+++ b/packages/client/src/components/TurnDiffSummary.tsx
@@ -1,0 +1,259 @@
+import { memo, useMemo, useState } from "react";
+import { useSessionMetadata } from "../contexts/SessionMetadataContext";
+import type { RenderItem, ToolCallItem } from "../types/renderItems";
+import type { PatchHunk } from "./renderers/tools/types";
+import { Modal } from "./ui/Modal";
+
+interface EditInputWithAugment {
+  file_path?: string;
+  _structuredPatch?: PatchHunk[];
+  _diffHtml?: string;
+  _rawPatch?: string;
+}
+
+interface EditStructuredResult {
+  filePath?: string;
+  structuredPatch?: PatchHunk[];
+}
+
+export interface TurnDiffEntry {
+  id: string;
+  filePath: string;
+  structuredPatch: PatchHunk[];
+  diffHtml?: string;
+  additions: number;
+  deletions: number;
+}
+
+function isEditToolCall(item: RenderItem): item is ToolCallItem {
+  return item.type === "tool_call" && item.toolName === "Edit";
+}
+
+function extractFilePathFromRawPatch(rawPatch?: string): string | undefined {
+  if (typeof rawPatch !== "string" || rawPatch.trim().length === 0) {
+    return undefined;
+  }
+
+  const lines = rawPatch.replace(/\r\n/g, "\n").split("\n");
+  for (const line of lines) {
+    const match = line.match(
+      /^\*\*\*\s+(?:Update File|Add File|Delete File|Move to):\s+(.+?)\s*$/,
+    );
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return undefined;
+}
+
+function countPatchChanges(structuredPatch: PatchHunk[]) {
+  let additions = 0;
+  let deletions = 0;
+
+  for (const hunk of structuredPatch) {
+    for (const line of hunk.lines) {
+      if (line.startsWith("+")) additions += 1;
+      if (line.startsWith("-")) deletions += 1;
+    }
+  }
+
+  return { additions, deletions };
+}
+
+export function collectTurnDiffEntries(items: RenderItem[]): TurnDiffEntry[] {
+  const entries: TurnDiffEntry[] = [];
+
+  for (const item of items) {
+    if (!isEditToolCall(item) || item.status !== "complete") {
+      continue;
+    }
+
+    const input = (item.toolInput ?? {}) as EditInputWithAugment;
+    const structured = (item.toolResult?.structured ??
+      {}) as EditStructuredResult;
+    const structuredPatch =
+      structured.structuredPatch ?? input._structuredPatch ?? [];
+    if (structuredPatch.length === 0) {
+      continue;
+    }
+
+    const filePath =
+      structured.filePath ??
+      input.file_path ??
+      extractFilePathFromRawPatch(input._rawPatch);
+    if (!filePath) {
+      continue;
+    }
+
+    const { additions, deletions } = countPatchChanges(structuredPatch);
+    entries.push({
+      id: item.id,
+      filePath,
+      structuredPatch,
+      diffHtml: input._diffHtml,
+      additions,
+      deletions,
+    });
+  }
+
+  return entries;
+}
+
+function getRelativePath(filePath: string, projectPath: string | null): string {
+  if (projectPath && filePath.startsWith(projectPath)) {
+    const relative = filePath.slice(projectPath.length);
+    return relative.startsWith("/") ? relative.slice(1) : relative;
+  }
+  return filePath;
+}
+
+function splitDisplayPath(filePath: string): {
+  directory: string;
+  fileName: string;
+} {
+  const normalized = filePath.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash === -1) {
+    return { directory: "", fileName: normalized };
+  }
+
+  return {
+    directory: normalized.slice(0, lastSlash + 1),
+    fileName: normalized.slice(lastSlash + 1),
+  };
+}
+
+const HighlightedDiff = memo(function HighlightedDiff({
+  diffHtml,
+}: {
+  diffHtml: string;
+}) {
+  return (
+    <div
+      className="highlighted-diff"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: shiki output is safe
+      dangerouslySetInnerHTML={{ __html: diffHtml }}
+    />
+  );
+});
+
+const DiffLines = memo(function DiffLines({ lines }: { lines: string[] }) {
+  return (
+    <div className="diff-hunk">
+      <pre className="diff-content">
+        {lines.map((line, i) => {
+          const prefix = line[0];
+          const className =
+            prefix === "-"
+              ? "diff-removed"
+              : prefix === "+"
+                ? "diff-added"
+                : "diff-context";
+          return (
+            <div key={`${i}-${line.slice(0, 50)}`} className={className}>
+              {line}
+            </div>
+          );
+        })}
+      </pre>
+    </div>
+  );
+});
+
+export const TurnDiffSummary = memo(function TurnDiffSummary({
+  items,
+}: {
+  items: RenderItem[];
+}) {
+  const { projectPath } = useSessionMetadata();
+  const entries = useMemo(() => collectTurnDiffEntries(items), [items]);
+  const [selectedEntry, setSelectedEntry] = useState<TurnDiffEntry | null>(
+    null,
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const totalAdditions = entries.reduce(
+    (sum, entry) => sum + entry.additions,
+    0,
+  );
+  const totalDeletions = entries.reduce(
+    (sum, entry) => sum + entry.deletions,
+    0,
+  );
+
+  return (
+    <>
+      <div className="turn-diff-summary timeline-item">
+        <div className="turn-diff-summary-header">
+          <div className="turn-diff-summary-heading">
+            <span className="turn-diff-summary-title">Changes</span>
+            <span className="turn-diff-summary-count">
+              {entries.length} files
+            </span>
+          </div>
+          <span className="git-line-counts turn-diff-total-counts">
+            <span className="git-lines-added">+{totalAdditions}</span>
+            <span className="git-lines-deleted">-{totalDeletions}</span>
+          </span>
+        </div>
+        <ul className="git-file-list turn-diff-file-list">
+          {entries.map((entry) => {
+            const displayPath = getRelativePath(entry.filePath, projectPath);
+            const { directory, fileName } = splitDisplayPath(displayPath);
+
+            return (
+              <li key={entry.id} className="git-file-item turn-diff-file-item">
+                <button
+                  type="button"
+                  className="turn-diff-file-button"
+                  onClick={() => setSelectedEntry(entry)}
+                >
+                  <span className="turn-diff-path">
+                    {directory ? (
+                      <span className="turn-diff-path-directory">
+                        {directory}
+                      </span>
+                    ) : null}
+                    <span className="turn-diff-path-filename">{fileName}</span>
+                  </span>
+                  <span className="git-line-counts turn-diff-line-counts">
+                    <span className="git-lines-added">+{entry.additions}</span>
+                    <span className="git-lines-deleted">
+                      -{entry.deletions}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {selectedEntry && (
+        <Modal
+          title={getRelativePath(selectedEntry.filePath, projectPath)}
+          onClose={() => setSelectedEntry(null)}
+        >
+          <div className="diff-modal-content">
+            <div className="diff-context-controls">
+              <span className="diff-context-path">
+                {getRelativePath(selectedEntry.filePath, projectPath)}
+              </span>
+            </div>
+            {selectedEntry.diffHtml ? (
+              <HighlightedDiff diffHtml={selectedEntry.diffHtml} />
+            ) : (
+              <DiffLines
+                lines={selectedEntry.structuredPatch.flatMap((h) => h.lines)}
+              />
+            )}
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+});

--- a/packages/client/src/components/TurnDiffSummary.tsx
+++ b/packages/client/src/components/TurnDiffSummary.tsx
@@ -6,6 +6,9 @@ import { Modal } from "./ui/Modal";
 
 interface EditInputWithAugment {
   file_path?: string;
+  old_string?: string;
+  new_string?: string;
+  replace_all?: boolean;
   _structuredPatch?: PatchHunk[];
   _diffHtml?: string;
   _rawPatch?: string;
@@ -14,6 +17,10 @@ interface EditInputWithAugment {
 interface EditStructuredResult {
   filePath?: string;
   structuredPatch?: PatchHunk[];
+  oldString?: string;
+  newString?: string;
+  originalFile?: string;
+  replaceAll?: boolean;
 }
 
 export interface TurnDiffEntry {
@@ -23,6 +30,12 @@ export interface TurnDiffEntry {
   diffHtml?: string;
   additions: number;
   deletions: number;
+}
+
+interface AggregatedTurnDiffEntry extends TurnDiffEntry {
+  baseOriginalFile?: string;
+  currentContent?: string;
+  canRebuildFinalDiff: boolean;
 }
 
 function isEditToolCall(item: RenderItem): item is ToolCallItem {
@@ -61,8 +74,98 @@ function countPatchChanges(structuredPatch: PatchHunk[]) {
   return { additions, deletions };
 }
 
+function applyEditToContent(
+  content: string,
+  oldString: string,
+  newString: string,
+  replaceAll: boolean,
+): string | null {
+  if (oldString === "") {
+    return `${newString}${content}`;
+  }
+
+  if (!content.includes(oldString)) {
+    return null;
+  }
+
+  if (replaceAll) {
+    return content.split(oldString).join(newString);
+  }
+
+  return content.replace(oldString, newString);
+}
+
+function buildStructuredPatchFromContents(
+  oldContent: string,
+  newContent: string,
+): PatchHunk[] {
+  if (oldContent === newContent) {
+    return [];
+  }
+
+  const oldLines = oldContent.split("\n");
+  const newLines = newContent.split("\n");
+  const oldLen = oldLines.length;
+  const newLen = newLines.length;
+  const dp: number[][] = Array.from({ length: oldLen + 1 }, () =>
+    Array<number>(newLen + 1).fill(0),
+  );
+
+  for (let i = oldLen - 1; i >= 0; i -= 1) {
+    for (let j = newLen - 1; j >= 0; j -= 1) {
+      if (oldLines[i] === newLines[j]) {
+        dp[i]![j] = (dp[i + 1]![j + 1] ?? 0) + 1;
+      } else {
+        dp[i]![j] = Math.max(dp[i + 1]![j] ?? 0, dp[i]![j + 1] ?? 0);
+      }
+    }
+  }
+
+  const lines: string[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < oldLen && j < newLen) {
+    if (oldLines[i] === newLines[j]) {
+      lines.push(` ${oldLines[i]}`);
+      i += 1;
+      j += 1;
+      continue;
+    }
+
+    if ((dp[i + 1]![j] ?? 0) >= (dp[i]![j + 1] ?? 0)) {
+      lines.push(`-${oldLines[i]}`);
+      i += 1;
+    } else {
+      lines.push(`+${newLines[j]}`);
+      j += 1;
+    }
+  }
+
+  while (i < oldLen) {
+    lines.push(`-${oldLines[i]}`);
+    i += 1;
+  }
+
+  while (j < newLen) {
+    lines.push(`+${newLines[j]}`);
+    j += 1;
+  }
+
+  return [
+    {
+      oldStart: 1,
+      oldLines: oldLen,
+      newStart: 1,
+      newLines: newLen,
+      lines,
+    },
+  ];
+}
+
 export function collectTurnDiffEntries(items: RenderItem[]): TurnDiffEntry[] {
-  const entries: TurnDiffEntry[] = [];
+  const entriesByFilePath = new Map<string, AggregatedTurnDiffEntry>();
+  const entryOrder: string[] = [];
 
   for (const item of items) {
     if (!isEditToolCall(item) || item.status !== "complete") {
@@ -74,9 +177,6 @@ export function collectTurnDiffEntries(items: RenderItem[]): TurnDiffEntry[] {
       {}) as EditStructuredResult;
     const structuredPatch =
       structured.structuredPatch ?? input._structuredPatch ?? [];
-    if (structuredPatch.length === 0) {
-      continue;
-    }
 
     const filePath =
       structured.filePath ??
@@ -86,18 +186,141 @@ export function collectTurnDiffEntries(items: RenderItem[]): TurnDiffEntry[] {
       continue;
     }
 
-    const { additions, deletions } = countPatchChanges(structuredPatch);
-    entries.push({
+    const oldString = structured.oldString ?? input.old_string;
+    const newString = structured.newString ?? input.new_string;
+    const originalFile = structured.originalFile;
+    const replaceAll = structured.replaceAll ?? input.replace_all ?? false;
+    const canRebuildFromContent =
+      typeof originalFile === "string" &&
+      typeof oldString === "string" &&
+      typeof newString === "string";
+
+    if (structuredPatch.length === 0 && !canRebuildFromContent) {
+      continue;
+    }
+    const existingEntry = entriesByFilePath.get(filePath);
+    if (existingEntry) {
+      existingEntry.id = item.id;
+
+      if (
+        existingEntry.canRebuildFinalDiff &&
+        existingEntry.currentContent !== undefined &&
+        typeof oldString === "string" &&
+        typeof newString === "string"
+      ) {
+        const nextContent = applyEditToContent(
+          existingEntry.currentContent,
+          oldString,
+          newString,
+          replaceAll,
+        );
+
+        if (nextContent !== null) {
+          const diffBase =
+            existingEntry.baseOriginalFile ?? existingEntry.currentContent;
+          existingEntry.currentContent = nextContent;
+          existingEntry.structuredPatch = buildStructuredPatchFromContents(
+            diffBase,
+            nextContent,
+          );
+          const counts = countPatchChanges(existingEntry.structuredPatch);
+          existingEntry.additions = counts.additions;
+          existingEntry.deletions = counts.deletions;
+          existingEntry.diffHtml = undefined;
+          continue;
+        }
+      }
+
+      // Rebuild path failed — try using this edit's originalFile as a new base
+      if (canRebuildFromContent && typeof originalFile === "string") {
+        const nextContent = applyEditToContent(
+          originalFile,
+          oldString as string,
+          newString as string,
+          replaceAll,
+        );
+        if (nextContent !== null) {
+          const base = existingEntry.baseOriginalFile ?? originalFile;
+          existingEntry.baseOriginalFile = base;
+          existingEntry.currentContent = nextContent;
+          existingEntry.canRebuildFinalDiff = true;
+          existingEntry.structuredPatch = buildStructuredPatchFromContents(
+            base,
+            nextContent,
+          );
+          const counts = countPatchChanges(existingEntry.structuredPatch);
+          existingEntry.additions = counts.additions;
+          existingEntry.deletions = counts.deletions;
+          existingEntry.diffHtml = undefined;
+          continue;
+        }
+      }
+
+      existingEntry.canRebuildFinalDiff = false;
+      if (structuredPatch.length > 0) {
+        existingEntry.structuredPatch.push(...structuredPatch);
+        const mergedCounts = countPatchChanges(existingEntry.structuredPatch);
+        existingEntry.additions = mergedCounts.additions;
+        existingEntry.deletions = mergedCounts.deletions;
+        existingEntry.diffHtml = undefined;
+      }
+      continue;
+    }
+
+    const initialEntry: AggregatedTurnDiffEntry = {
       id: item.id,
       filePath,
-      structuredPatch,
+      structuredPatch: [...structuredPatch],
       diffHtml: input._diffHtml,
-      additions,
-      deletions,
-    });
+      additions: 0,
+      deletions: 0,
+      baseOriginalFile: originalFile,
+      currentContent: undefined,
+      canRebuildFinalDiff: false,
+    };
+
+    if (
+      typeof originalFile === "string" &&
+      typeof oldString === "string" &&
+      typeof newString === "string"
+    ) {
+      const nextContent = applyEditToContent(
+        originalFile,
+        oldString,
+        newString,
+        replaceAll,
+      );
+      if (nextContent !== null) {
+        initialEntry.baseOriginalFile = originalFile;
+        initialEntry.currentContent = nextContent;
+        initialEntry.canRebuildFinalDiff = true;
+        initialEntry.structuredPatch = buildStructuredPatchFromContents(
+          originalFile,
+          nextContent,
+        );
+        initialEntry.diffHtml = undefined;
+      }
+    }
+
+    const initialCounts = countPatchChanges(initialEntry.structuredPatch);
+    initialEntry.additions = initialCounts.additions;
+    initialEntry.deletions = initialCounts.deletions;
+
+    entriesByFilePath.set(filePath, initialEntry);
+    entryOrder.push(filePath);
   }
 
-  return entries;
+  return entryOrder
+    .map((filePath) => entriesByFilePath.get(filePath))
+    .filter((entry): entry is AggregatedTurnDiffEntry => entry !== undefined)
+    .map(({ id, filePath, structuredPatch, diffHtml, additions, deletions }) => ({
+      id,
+      filePath,
+      structuredPatch,
+      diffHtml,
+      additions,
+      deletions,
+    }));
 }
 
 function getRelativePath(filePath: string, projectPath: string | null): string {

--- a/packages/client/src/components/__tests__/MessageList.test.ts
+++ b/packages/client/src/components/__tests__/MessageList.test.ts
@@ -6,6 +6,7 @@ import {
   MessageList,
   buildAssistantTurnRenderSegments,
   getDisplayAssistantTurnItems,
+  hasPendingOperation,
   getStreamingTurnSummary,
   groupAssistantTurnSegments,
 } from "../MessageList";
@@ -20,13 +21,17 @@ function createTextItem(id: string, text: string): RenderItem {
   };
 }
 
-function createToolCallItem(id: string, toolName: string): RenderItem {
+function createToolCallItem(
+  id: string,
+  toolName: string,
+  status: "pending" | "complete" | "error" | "aborted" = "complete",
+): RenderItem {
   return {
     type: "tool_call",
     id,
     toolName,
     toolInput: {},
-    status: "complete",
+    status,
     sourceMessages: [],
   };
 }
@@ -90,6 +95,26 @@ describe("groupAssistantTurnSegments", () => {
       kind: "items",
       items: [{ type: "text", id: "text-2" }],
     });
+  });
+});
+
+describe("hasPendingOperation", () => {
+  it("returns true when any operation is still pending", () => {
+    expect(
+      hasPendingOperation([
+        createToolCallItem("tool-1", "Read", "pending"),
+        createToolCallItem("tool-2", "Bash"),
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when all operations are finished", () => {
+    expect(
+      hasPendingOperation([
+        createToolCallItem("tool-1", "Read"),
+        createToolCallItem("tool-2", "Bash", "aborted"),
+      ]),
+    ).toBe(false);
   });
 });
 
@@ -395,6 +420,8 @@ describe("streaming fallback layout", () => {
   });
 
   it("renders the initial working summary inside an assistant-turn placeholder", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-17T10:01:00.000Z"));
     vi.stubGlobal("localStorage", {
       getItem: vi.fn().mockReturnValue("false"),
       setItem: vi.fn(),
@@ -419,5 +446,6 @@ describe("streaming fallback layout", () => {
 
     expect(html).toContain("Working for 0s");
     expect(html).toContain("assistant-turn assistant-turn-placeholder");
+    vi.useRealTimers();
   });
 });

--- a/packages/client/src/components/__tests__/MessageList.test.ts
+++ b/packages/client/src/components/__tests__/MessageList.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { groupAssistantTurnSegments } from "../MessageList";
 import type { RenderItem } from "../../types/renderItems";
+import { groupAssistantTurnSegments } from "../MessageList";
 
 function createTextItem(id: string, text: string): RenderItem {
   return {

--- a/packages/client/src/components/__tests__/MessageList.test.ts
+++ b/packages/client/src/components/__tests__/MessageList.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { RenderItem } from "../../types/renderItems";
-import { groupAssistantTurnSegments } from "../MessageList";
+import {
+  buildAssistantTurnRenderSegments,
+  groupAssistantTurnSegments,
+} from "../MessageList";
 
 function createTextItem(id: string, text: string): RenderItem {
   return {
@@ -71,5 +74,51 @@ describe("groupAssistantTurnSegments", () => {
       kind: "items",
       items: [{ type: "text", id: "text-2" }],
     });
+  });
+});
+
+describe("buildAssistantTurnRenderSegments", () => {
+  it("folds completed reasoning work and keeps the final text visible", () => {
+    const segments = buildAssistantTurnRenderSegments(
+      [
+        {
+          ...createTextItem("text-1", "Planning the next step."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:10.000Z" }],
+        },
+        {
+          ...createTextItem("text-2", "Done."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:01:12.000Z" }],
+        },
+      ],
+      false,
+    );
+
+    expect(segments).toHaveLength(1);
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 1m 12s",
+      collapsedItems: [{ id: "text-1" }, { id: "tool-1" }],
+      visibleItems: [{ id: "text-2" }],
+    });
+  });
+
+  it("does not fold while the turn is still streaming", () => {
+    const segments = buildAssistantTurnRenderSegments(
+      [
+        createTextItem("text-1", "Planning the next step."),
+        createToolCallItem("tool-1", "Read"),
+        createTextItem("text-2", "Still working..."),
+      ],
+      true,
+    );
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toMatchObject({ kind: "items" });
+    expect(segments[1]).toMatchObject({ kind: "operations" });
+    expect(segments[2]).toMatchObject({ kind: "items" });
   });
 });

--- a/packages/client/src/components/__tests__/MessageList.test.ts
+++ b/packages/client/src/components/__tests__/MessageList.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { groupAssistantTurnSegments } from "../MessageList";
+import type { RenderItem } from "../../types/renderItems";
+
+function createTextItem(id: string, text: string): RenderItem {
+  return {
+    type: "text",
+    id,
+    text,
+    sourceMessages: [],
+  };
+}
+
+function createToolCallItem(id: string, toolName: string): RenderItem {
+  return {
+    type: "tool_call",
+    id,
+    toolName,
+    toolInput: {},
+    status: "complete",
+    sourceMessages: [],
+  };
+}
+
+describe("groupAssistantTurnSegments", () => {
+  it("keeps descriptive text visible and collapses consecutive operations into one segment", () => {
+    const segments = groupAssistantTurnSegments([
+      createTextItem("text-1", "Planning the next step."),
+      createToolCallItem("tool-1", "Read"),
+      createToolCallItem("tool-2", "Bash"),
+      createToolCallItem("tool-3", "WriteStdin"),
+      createTextItem("text-2", "Found the root cause."),
+    ]);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toMatchObject({
+      kind: "items",
+      items: [{ type: "text", id: "text-1" }],
+    });
+    expect(segments[1]).toMatchObject({
+      kind: "operations",
+      items: [
+        { type: "tool_call", id: "tool-1" },
+        { type: "tool_call", id: "tool-2" },
+        { type: "tool_call", id: "tool-3" },
+      ],
+    });
+    expect(segments[2]).toMatchObject({
+      kind: "items",
+      items: [{ type: "text", id: "text-2" }],
+    });
+  });
+
+  it("collapses a single isolated operation", () => {
+    const segments = groupAssistantTurnSegments([
+      createTextItem("text-1", "Checking one thing."),
+      createToolCallItem("tool-1", "Read"),
+      createTextItem("text-2", "Done."),
+    ]);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[0]).toMatchObject({
+      kind: "items",
+      items: [{ type: "text", id: "text-1" }],
+    });
+    expect(segments[1]).toMatchObject({
+      kind: "operations",
+      items: [{ type: "tool_call", id: "tool-1" }],
+    });
+    expect(segments[2]).toMatchObject({
+      kind: "items",
+      items: [{ type: "text", id: "text-2" }],
+    });
+  });
+});

--- a/packages/client/src/components/__tests__/MessageList.test.ts
+++ b/packages/client/src/components/__tests__/MessageList.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Message } from "../../types";
 import type { RenderItem } from "../../types/renderItems";
 import {
+  MessageList,
   buildAssistantTurnRenderSegments,
+  getDisplayAssistantTurnItems,
+  getStreamingTurnSummary,
   groupAssistantTurnSegments,
 } from "../MessageList";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 function createTextItem(id: string, text: string): RenderItem {
   return {
@@ -20,6 +26,16 @@ function createToolCallItem(id: string, toolName: string): RenderItem {
     id,
     toolName,
     toolInput: {},
+    status: "complete",
+    sourceMessages: [],
+  };
+}
+
+function createThinkingItem(id: string, thinking: string): RenderItem {
+  return {
+    type: "thinking",
+    id,
+    thinking,
     status: "complete",
     sourceMessages: [],
   };
@@ -95,6 +111,21 @@ describe("buildAssistantTurnRenderSegments", () => {
         },
       ],
       false,
+      [
+        {
+          ...createTextItem("text-1", "Planning the next step."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:10.000Z" }],
+        },
+        {
+          ...createTextItem("text-2", "Done."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:01:12.000Z" }],
+        },
+      ],
+      "2026-05-17T10:00:00.000Z",
     );
 
     expect(segments).toHaveLength(1);
@@ -103,6 +134,194 @@ describe("buildAssistantTurnRenderSegments", () => {
       summary: "Worked for 1m 12s",
       collapsedItems: [{ id: "text-1" }, { id: "tool-1" }],
       visibleItems: [{ id: "text-2" }],
+    });
+  });
+
+  it("uses the final visible summary text timestamp as the completed end time", () => {
+    const segments = buildAssistantTurnRenderSegments(
+      [
+        {
+          ...createTextItem("text-1", "Thinking..."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:10.000Z" }],
+        },
+        {
+          ...createTextItem("text-2", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:18.000Z" }],
+        },
+      ],
+      false,
+      [
+        {
+          ...createTextItem("text-1", "Thinking..."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:10.000Z" }],
+        },
+        {
+          ...createTextItem("text-2", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:18.000Z" }],
+        },
+      ],
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 18s",
+    });
+  });
+
+  it("includes hidden thinking items in worked-for timing", () => {
+    const visibleItems = getDisplayAssistantTurnItems([
+      {
+        ...createThinkingItem("thinking-1", "Hidden thinking"),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+      },
+      {
+        ...createToolCallItem("tool-1", "Read"),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:20.000Z" }],
+      },
+      {
+        ...createTextItem("text-1", "Final answer."),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+      },
+    ]);
+
+    const segments = buildAssistantTurnRenderSegments(
+      visibleItems,
+      false,
+      [
+        {
+          ...createThinkingItem("thinking-1", "Hidden thinking"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:20.000Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+        },
+      ],
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 30s",
+    });
+  });
+
+  it("prefers explicit turnStartedAt when provided", () => {
+    const visibleItems = getDisplayAssistantTurnItems([
+      {
+        ...createThinkingItem("thinking-1", "Hidden thinking"),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:05.000Z" }],
+      },
+      {
+        ...createToolCallItem("tool-1", "Read"),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:20.000Z" }],
+      },
+      {
+        ...createTextItem("text-1", "Final answer."),
+        sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+      },
+    ]);
+
+    const segments = buildAssistantTurnRenderSegments(
+      visibleItems,
+      false,
+      [
+        {
+          ...createThinkingItem("thinking-1", "Hidden thinking"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:05.000Z" }],
+        },
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:20.000Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+        },
+      ],
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 30s",
+    });
+  });
+
+  it("uses the user prompt timestamp as the completed turn start when provided", () => {
+    const segments = buildAssistantTurnRenderSegments(
+      [
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:05.000Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+        },
+      ],
+      false,
+      [
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:05.000Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:30.000Z" }],
+        },
+      ],
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 30s",
+    });
+  });
+
+  it("falls back to turn item timestamps when turnStartedAt is missing", () => {
+    const segments = buildAssistantTurnRenderSegments(
+      [
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.100Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.650Z" }],
+        },
+      ],
+      false,
+      [
+        {
+          ...createToolCallItem("tool-1", "Read"),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.100Z" }],
+        },
+        {
+          ...createTextItem("text-1", "Final answer."),
+          sourceMessages: [{ timestamp: "2026-05-17T10:00:00.650Z" }],
+        },
+      ],
+      null,
+    );
+
+    expect(segments[0]).toMatchObject({
+      kind: "folded_reasoning",
+      summary: "Worked for 1s",
     });
   });
 
@@ -120,5 +339,85 @@ describe("buildAssistantTurnRenderSegments", () => {
     expect(segments[0]).toMatchObject({ kind: "items" });
     expect(segments[1]).toMatchObject({ kind: "operations" });
     expect(segments[2]).toMatchObject({ kind: "items" });
+  });
+});
+
+describe("getDisplayAssistantTurnItems", () => {
+  it("hides all thinking items from assistant turns", () => {
+    const items = getDisplayAssistantTurnItems([
+      createThinkingItem("thinking-1", "Reasoning [internal]"),
+      createThinkingItem("thinking-2", "Visible thinking"),
+      createToolCallItem("tool-1", "Read"),
+      createTextItem("text-1", "Current answer"),
+    ]);
+
+    expect(items).toMatchObject([
+      { type: "tool_call", id: "tool-1" },
+      { type: "text", id: "text-1" },
+    ]);
+  });
+});
+
+describe("getStreamingTurnSummary", () => {
+  it("shows a working label based on the current time", () => {
+    const summary = getStreamingTurnSummary(
+      Date.parse("2026-05-17T10:00:12.000Z"),
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(summary).toBe("Working for 12s");
+  });
+
+  it("rounds sub-second active turns to the nearest second", () => {
+    const summary = getStreamingTurnSummary(
+      Date.parse("2026-05-17T10:00:00.450Z"),
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(summary).toBe("Working for 0s");
+  });
+});
+
+describe("streaming fallback duration", () => {
+  it("starts fallback timing from the latest user prompt when older assistant turns exist", () => {
+    const summary = getStreamingTurnSummary(
+      Date.parse("2026-05-17T10:00:12.000Z"),
+      "2026-05-17T10:00:00.000Z",
+    );
+
+    expect(summary).toBe("Working for 12s");
+  });
+});
+
+describe("streaming fallback layout", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the initial working summary inside an assistant-turn placeholder", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn().mockReturnValue("false"),
+      setItem: vi.fn(),
+    });
+
+    const messages: Message[] = [
+      {
+        uuid: "user-1",
+        type: "user",
+        timestamp: "2026-05-17T10:01:00.000Z",
+        content: "Next prompt",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      createElement(MessageList, {
+        messages,
+        isProcessing: true,
+        turnStartedAt: "2026-05-17T10:01:00.000Z",
+      }),
+    );
+
+    expect(html).toContain("Working for 0s");
+    expect(html).toContain("assistant-turn assistant-turn-placeholder");
   });
 });

--- a/packages/client/src/components/__tests__/TurnDiffSummary.test.tsx
+++ b/packages/client/src/components/__tests__/TurnDiffSummary.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { RenderItem } from "../../types/renderItems";
+import { collectTurnDiffEntries } from "../TurnDiffSummary";
+
+describe("collectTurnDiffEntries", () => {
+  it("collects completed edit diffs with line counts", () => {
+    const items: RenderItem[] = [
+      {
+        type: "tool_call",
+        id: "edit-1",
+        toolName: "Edit",
+        toolInput: {
+          file_path: "src/app.ts",
+          _diffHtml: "<pre>diff</pre>",
+        },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {
+            filePath: "src/app.ts",
+            structuredPatch: [
+              {
+                oldStart: 1,
+                oldLines: 1,
+                newStart: 1,
+                newLines: 2,
+                lines: ["-const a = 1;", "+const a = 2;", "+const b = 3;"],
+              },
+            ],
+          },
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+    ];
+
+    expect(collectTurnDiffEntries(items)).toEqual([
+      expect.objectContaining({
+        id: "edit-1",
+        filePath: "src/app.ts",
+        additions: 2,
+        deletions: 1,
+        diffHtml: "<pre>diff</pre>",
+      }),
+    ]);
+  });
+
+  it("ignores non-edit and incomplete tool calls", () => {
+    const items: RenderItem[] = [
+      {
+        type: "tool_call",
+        id: "read-1",
+        toolName: "Read",
+        toolInput: {},
+        status: "complete",
+        sourceMessages: [],
+      },
+      {
+        type: "tool_call",
+        id: "edit-2",
+        toolName: "Edit",
+        toolInput: { file_path: "src/pending.ts" },
+        status: "pending",
+        sourceMessages: [],
+      },
+    ];
+
+    expect(collectTurnDiffEntries(items)).toEqual([]);
+  });
+
+  it("falls back to raw patch metadata for file path extraction", () => {
+    const items: RenderItem[] = [
+      {
+        type: "tool_call",
+        id: "edit-3",
+        toolName: "Edit",
+        toolInput: {
+          _rawPatch: "*** Update File: src/raw.ts\n@@\n-old\n+new\n",
+          _structuredPatch: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              lines: ["-old", "+new"],
+            },
+          ],
+        },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {},
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+    ];
+
+    expect(collectTurnDiffEntries(items)).toEqual([
+      expect.objectContaining({
+        filePath: "src/raw.ts",
+        additions: 1,
+        deletions: 1,
+      }),
+    ]);
+  });
+});

--- a/packages/client/src/components/__tests__/TurnDiffSummary.test.tsx
+++ b/packages/client/src/components/__tests__/TurnDiffSummary.test.tsx
@@ -104,4 +104,133 @@ describe("collectTurnDiffEntries", () => {
       }),
     ]);
   });
+
+  it("recovers via edit originalFile when canRebuildFinalDiff is false", () => {
+    // First edit has no originalFile so canRebuildFinalDiff stays false.
+    // Second edit provides originalFile — should still produce a correct patch.
+    const items: RenderItem[] = [
+      {
+        type: "tool_call",
+        id: "edit-1",
+        toolName: "Edit",
+        toolInput: { file_path: "src/app.ts" },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {
+            filePath: "src/app.ts",
+            structuredPatch: [
+              {
+                oldStart: 1,
+                oldLines: 1,
+                newStart: 1,
+                newLines: 1,
+                lines: ["-const a = 1;", "+const a = 2;"],
+              },
+            ],
+          },
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+      {
+        type: "tool_call",
+        id: "edit-2",
+        toolName: "Edit",
+        toolInput: { file_path: "src/app.ts" },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {
+            filePath: "src/app.ts",
+            oldString: "const a = 2;",
+            newString: "const b = 3;",
+            originalFile: "const a = 2;\nconst c = 4;",
+            replaceAll: false,
+            structuredPatch: [],
+          },
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+    ];
+
+    const result = collectTurnDiffEntries(items);
+    expect(result).toHaveLength(1);
+    // The second edit should not be silently dropped
+    expect(result[0]).toMatchObject({
+      filePath: "src/app.ts",
+      additions: 1,
+      deletions: 1,
+    });
+    const allLines = result[0]!.structuredPatch.flatMap((h) => h.lines);
+    expect(allLines).toContain("+const b = 3;");
+  });
+
+  it("merges multiple edits for the same file into one entry", () => {
+    const items: RenderItem[] = [
+      {
+        type: "tool_call",
+        id: "edit-1",
+        toolName: "Edit",
+        toolInput: {
+          file_path: "src/app.ts",
+          old_string: "const a = 1;",
+          new_string: "const a = 2;",
+        },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {
+            filePath: "src/app.ts",
+            oldString: "const a = 1;",
+            newString: "const a = 2;",
+            originalFile: "const a = 1;\nconst c = 4;",
+            replaceAll: false,
+            structuredPatch: [],
+          },
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+      {
+        type: "tool_call",
+        id: "edit-2",
+        toolName: "Edit",
+        toolInput: {
+          file_path: "src/app.ts",
+          old_string: "const a = 2;",
+          new_string: "const b = 3;",
+        },
+        toolResult: {
+          content: "",
+          isError: false,
+          structured: {
+            filePath: "src/app.ts",
+            oldString: "const a = 2;",
+            newString: "const b = 3;",
+            originalFile: "const a = 2;\nconst c = 4;",
+            replaceAll: false,
+            structuredPatch: [],
+          },
+        },
+        status: "complete",
+        sourceMessages: [],
+      },
+    ];
+
+    expect(collectTurnDiffEntries(items)).toEqual([
+      expect.objectContaining({
+        filePath: "src/app.ts",
+        additions: 1,
+        deletions: 1,
+        diffHtml: undefined,
+        structuredPatch: [
+          expect.objectContaining({
+            lines: ["-const a = 1;", "+const b = 3;", " const c = 4;"],
+          }),
+        ],
+      }),
+    ]);
+  });
 });

--- a/packages/client/src/components/blocks/TextBlock.tsx
+++ b/packages/client/src/components/blocks/TextBlock.tsx
@@ -1,7 +1,10 @@
 import { memo, useCallback, useEffect, useState } from "react";
+import { useSessionMetadata } from "../../contexts/SessionMetadataContext";
 import { useStreamingMarkdownContext } from "../../contexts/StreamingMarkdownContext";
 import { useStreamingMarkdown } from "../../hooks/useStreamingMarkdown";
+import { FileViewer } from "../FileViewer";
 import { LocalMediaModal, useLocalMediaClick } from "../LocalMediaModal";
+import { Modal } from "../ui/Modal";
 
 interface Props {
   text: string;
@@ -10,12 +13,42 @@ interface Props {
   augmentHtml?: string;
 }
 
+function toProjectRelativePath(
+  filePath: string,
+  projectPath: string | null,
+): string {
+  const normalizedFilePath = filePath.replaceAll("\\", "/");
+  if (!projectPath) {
+    return normalizedFilePath.replace(/^\.?\//, "");
+  }
+
+  const normalizedProjectPath = projectPath.replaceAll("\\", "/");
+  if (normalizedFilePath === normalizedProjectPath) {
+    return "";
+  }
+
+  const projectPrefix = normalizedProjectPath.endsWith("/")
+    ? normalizedProjectPath
+    : `${normalizedProjectPath}/`;
+
+  if (normalizedFilePath.startsWith(projectPrefix)) {
+    return normalizedFilePath.slice(projectPrefix.length);
+  }
+
+  return normalizedFilePath.replace(/^\.?\//, "");
+}
+
 export const TextBlock = memo(function TextBlock({
   text,
   isStreaming = false,
   augmentHtml,
 }: Props) {
+  const { projectId, projectPath } = useSessionMetadata();
   const [copied, setCopied] = useState(false);
+  const [fileModal, setFileModal] = useState<{
+    path: string;
+    lineNumber?: number;
+  } | null>(null);
 
   // Streaming markdown hook for server-rendered content
   const streamingMarkdown = useStreamingMarkdown();
@@ -61,7 +94,40 @@ export const TextBlock = memo(function TextBlock({
     }
   }, [text]);
 
-  const { modal, handleClick, closeModal } = useLocalMediaClick();
+  const { modal, handleClick: handleMediaClick, closeModal } =
+    useLocalMediaClick();
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      handleMediaClick(e);
+      if (e.defaultPrevented) return;
+
+      const fileTarget = (e.target as HTMLElement).closest?.(
+        "a.file-link, a.local-file-link",
+      ) as HTMLAnchorElement | null;
+      if (!fileTarget) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const path = fileTarget.getAttribute("data-file-path");
+      if (!path) return;
+      const relativePath = toProjectRelativePath(path, projectPath);
+      if (!relativePath) return;
+
+      const lineAttr = fileTarget.getAttribute("data-line");
+      const parsedLine =
+        lineAttr && /^\d+$/.test(lineAttr)
+          ? Number.parseInt(lineAttr, 10)
+          : undefined;
+
+      setFileModal({
+        path: relativePath,
+        lineNumber: parsedLine,
+      });
+    },
+    [handleMediaClick, projectPath],
+  );
 
   const showStreamingContent = isStreaming && useStreamingContent;
 
@@ -114,6 +180,19 @@ export const TextBlock = memo(function TextBlock({
           mediaType={modal.mediaType}
           onClose={closeModal}
         />
+      )}
+      {fileModal && (
+        <Modal
+          title={fileModal.path.split("/").pop() ?? fileModal.path}
+          onClose={() => setFileModal(null)}
+        >
+          <FileViewer
+            projectId={projectId}
+            filePath={fileModal.path}
+            lineNumber={fileModal.lineNumber}
+            onClose={() => setFileModal(null)}
+          />
+        </Modal>
       )}
     </div>
   );

--- a/packages/client/src/components/blocks/UserPromptBlock.tsx
+++ b/packages/client/src/components/blocks/UserPromptBlock.tsx
@@ -1,4 +1,5 @@
 import { memo, useState } from "react";
+import { getUploadUrl, isImageMimeType } from "../../api/upload";
 import { useRemoteImage } from "../../hooks/useRemoteImage";
 import {
   type UploadedFileInfo,
@@ -41,34 +42,6 @@ function OpenedFilesMetadata({ files }: { files: string[] }) {
       ))}
     </div>
   );
-}
-
-/**
- * Check if a MIME type is an image type
- */
-function isImageMimeType(mimeType: string): boolean {
-  return mimeType.startsWith("image/");
-}
-
-/**
- * Extract URL components from an uploaded file path.
- * Path format: /.../.yep-anywhere/uploads/{projectId}/{sessionId}/{filename}
- */
-function getUploadUrl(filePath: string): string | null {
-  // Split path and get last 3 components: projectId, sessionId, filename
-  const parts = filePath.split("/");
-  if (parts.length < 3) return null;
-
-  const filename = parts[parts.length - 1];
-  const sessionId = parts[parts.length - 2];
-  const projectId = parts[parts.length - 3];
-
-  if (!filename || !sessionId || !projectId) return null;
-
-  // Validate filename has UUID prefix
-  if (!/^[0-9a-f-]{36}_/.test(filename)) return null;
-
-  return `/api/projects/${projectId}/sessions/${sessionId}/upload/${encodeURIComponent(filename)}`;
 }
 
 function isInputImageBlock(block: ContentBlock): block is InputImageBlock {
@@ -231,11 +204,25 @@ function UploadedFileItem({ file }: { file: UploadedFileInfo }) {
       <>
         <button
           type="button"
-          className="uploaded-file uploaded-file-clickable"
+          className="uploaded-file uploaded-file-clickable uploaded-file-image"
           title={`${file.mimeType}, ${file.size}`}
           onClick={() => setShowModal(true)}
         >
-          📎 {file.originalName}
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={file.originalName}
+              className="uploaded-file-image-preview"
+            />
+          ) : (
+            <span className="uploaded-file-image-placeholder">Img</span>
+          )}
+          <span className="uploaded-file-image-meta">
+            <span className="uploaded-file-image-name">
+              {file.originalName}
+            </span>
+            <span className="uploaded-file-image-size">{file.size}</span>
+          </span>
         </button>
         {showModal && (
           <Modal title={file.originalName} onClose={() => setShowModal(false)}>
@@ -268,7 +255,7 @@ function UploadedFilesMetadata({ files }: { files: UploadedFileInfo[] }) {
   if (files.length === 0) return null;
 
   return (
-    <div className="user-prompt-metadata">
+    <div className="user-prompt-metadata uploaded-files-metadata">
       {files.map((file) => (
         <UploadedFileItem key={file.path} file={file} />
       ))}
@@ -338,10 +325,10 @@ export const UserPromptBlock = memo(function UserPromptBlock({
     if (!text) {
       const hasMetadata = openedFiles.length > 0 || uploadedFiles.length > 0;
       return hasMetadata ? (
-        <>
+        <div className="user-prompt-container">
           <UploadedFilesMetadata files={uploadedFiles} />
           <OpenedFilesMetadata files={openedFiles} />
-        </>
+        </div>
       ) : null;
     }
 
@@ -376,10 +363,10 @@ export const UserPromptBlock = memo(function UserPromptBlock({
   if (!text) {
     const hasMetadata = openedFiles.length > 0 || allUploadedFiles.length > 0;
     return hasMetadata ? (
-      <>
+      <div className="user-prompt-container">
         <UploadedFilesMetadata files={allUploadedFiles} />
         <OpenedFilesMetadata files={openedFiles} />
-      </>
+      </div>
     ) : (
       <div className="message message-user-prompt">
         <div className="message-content">

--- a/packages/client/src/components/blocks/UserPromptBlock.tsx
+++ b/packages/client/src/components/blocks/UserPromptBlock.tsx
@@ -205,6 +205,7 @@ function UploadedFileItem({ file }: { file: UploadedFileInfo }) {
         <button
           type="button"
           className="uploaded-file uploaded-file-clickable uploaded-file-image"
+          aria-label={file.originalName}
           title={`${file.mimeType}, ${file.size}`}
           onClick={() => setShowModal(true)}
         >
@@ -217,15 +218,12 @@ function UploadedFileItem({ file }: { file: UploadedFileInfo }) {
           ) : (
             <span className="uploaded-file-image-placeholder">Img</span>
           )}
-          <span className="uploaded-file-image-meta">
-            <span className="uploaded-file-image-name">
-              {file.originalName}
-            </span>
-            <span className="uploaded-file-image-size">{file.size}</span>
-          </span>
         </button>
         {showModal && (
-          <Modal title={file.originalName} onClose={() => setShowModal(false)}>
+          <Modal
+            title={`${file.originalName} (${file.size})`}
+            onClose={() => setShowModal(false)}
+          >
             <div className="uploaded-image-modal">
               {apiPath && loading && (
                 <div className="image-loading">Loading...</div>

--- a/packages/client/src/components/blocks/__tests__/UserPromptBlock.test.tsx
+++ b/packages/client/src/components/blocks/__tests__/UserPromptBlock.test.tsx
@@ -30,7 +30,10 @@ describe("UserPromptBlock", () => {
     expect(screen.getByText(/Please review this screenshot\./)).toBeDefined();
     expect(screen.getByText(/Thanks\./)).toBeDefined();
     expect(screen.queryByText("<image>")).toBeNull();
-    expect(screen.getByText(/pasted-image-1\.png/)).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /pasted-image-1\.png/i }),
+    ).toBeDefined();
+    expect(screen.queryByText(/pasted-image-1\.png/)).toBeNull();
     expect(screen.queryByText(/data:image\/png;base64/i)).toBeNull();
   });
 
@@ -57,6 +60,7 @@ describe("UserPromptBlock", () => {
     });
     fireEvent.click(attachmentButton);
 
+    expect(screen.getByText("pasted-image-1.png (3 B)")).toBeDefined();
     expect(
       screen.getByRole("dialog").querySelector('img[alt="pasted-image-1.png"]'),
     ).not.toBeNull();

--- a/packages/client/src/components/blocks/__tests__/UserPromptBlock.test.tsx
+++ b/packages/client/src/components/blocks/__tests__/UserPromptBlock.test.tsx
@@ -58,8 +58,8 @@ describe("UserPromptBlock", () => {
     fireEvent.click(attachmentButton);
 
     expect(
-      screen.getByRole("img", { name: /pasted-image-1\.png/i }),
-    ).toBeDefined();
+      screen.getByRole("dialog").querySelector('img[alt="pasted-image-1.png"]'),
+    ).not.toBeNull();
   });
 
   it("uses file_path name for Codex input_image attachments", () => {
@@ -83,5 +83,23 @@ describe("UserPromptBlock", () => {
     expect(screen.getByText(/Annotated image:/)).toBeDefined();
     expect(screen.queryByText("<image>")).toBeNull();
     expect(screen.getByText(/annotated-shot\.jpg/)).toBeDefined();
+  });
+
+  it("keeps attachment-only prompts in the user prompt container", () => {
+    const content: ContentBlock[] = [
+      {
+        type: "input_image",
+        image_url: "data:image/png;base64,AAAA",
+      },
+    ];
+
+    const { container } = render(
+      <I18nProvider>
+        <UserPromptBlock content={content} />
+      </I18nProvider>,
+    );
+
+    expect(container.querySelector(".user-prompt-container")).not.toBeNull();
+    expect(container.querySelector(".uploaded-file-image")).not.toBeNull();
   });
 });

--- a/packages/client/src/hooks/useSession.ts
+++ b/packages/client/src/hooks/useSession.ts
@@ -102,6 +102,7 @@ export function useSession(
   const [processState, setProcessState] = useState<ProcessState>(
     initialStatus ? "in-turn" : "idle",
   );
+  const [turnStartedAt, setTurnStartedAt] = useState<string | null>(null);
   const [pendingInputRequest, setPendingInputRequest] =
     useState<InputRequest | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -526,6 +527,9 @@ export function useSession(
         event.activity === "hold"
       ) {
         setProcessState(event.activity);
+        if (event.activity !== "in-turn") {
+          setTurnStartedAt(null);
+        }
       }
 
       // If activity bus says waiting-input but we don't have the request,
@@ -796,6 +800,7 @@ export function useSession(
         const statusData = data as {
           eventType: string;
           state: string;
+          turnStartedAt?: string;
           request?: InputRequest;
         };
         // Track process state (in-turn, idle, waiting-input, hold)
@@ -806,6 +811,15 @@ export function useSession(
           statusData.state === "hold"
         ) {
           setProcessState(statusData.state as ProcessState);
+          if (statusData.state !== "in-turn") {
+            setTurnStartedAt(null);
+          }
+        }
+        if (
+          statusData.state === "in-turn" &&
+          typeof statusData.turnStartedAt === "string"
+        ) {
+          setTurnStartedAt(statusData.turnStartedAt);
         }
         // Capture pending input request when waiting for user input
         if (statusData.state === "waiting-input" && statusData.request) {
@@ -840,6 +854,7 @@ export function useSession(
           eventType: string;
           sessionId?: string;
           state?: string;
+          turnStartedAt?: string;
           permissionMode?: PermissionMode;
           modeVersion?: number;
           request?: InputRequest;
@@ -866,6 +881,14 @@ export function useSession(
           connectedData.state === "hold"
         ) {
           setProcessState(connectedData.state as ProcessState);
+        }
+        if (
+          connectedData.state === "in-turn" &&
+          typeof connectedData.turnStartedAt === "string"
+        ) {
+          setTurnStartedAt(connectedData.turnStartedAt);
+        } else {
+          setTurnStartedAt(null);
         }
         // Restore pending input request if state is waiting-input, clear if not
         // (handles reconnection after another tab already approved/denied)
@@ -1060,6 +1083,7 @@ export function useSession(
     markdownAugments, // Pre-rendered markdown HTML from REST response (keyed by blockId)
     status,
     processState,
+    turnStartedAt,
     isCompacting, // True when context is being compressed
     isHeld: processState === "hold", // Derived from process state
     pendingInputRequest,

--- a/packages/client/src/pages/GlobalSessionsPage.tsx
+++ b/packages/client/src/pages/GlobalSessionsPage.tsx
@@ -753,58 +753,53 @@ export function GlobalSessionsPage() {
                   className={`session-list ${isSelectionMode ? "session-list--selection-mode" : ""}`}
                 >
                   {filteredSessions.map((session) => (
-                    <div
+                    <SessionListItem
                       key={session.id}
-                      onTouchStart={(e) => handleLongPressStart(session.id, e)}
-                      onTouchMove={handleTouchMove}
-                      onTouchEnd={handleLongPressEnd}
-                      onTouchCancel={handleLongPressEnd}
-                      onMouseDown={(e) =>
-                        !isWideScreen && handleLongPressStart(session.id, e)
-                      }
-                      onMouseUp={handleLongPressEnd}
-                      onMouseLeave={handleLongPressEnd}
-                      onContextMenu={handleContextMenu}
-                    >
-                      <SessionListItem
-                        sessionId={session.id}
-                        projectId={session.projectId}
-                        title={getSessionDisplayTitle(session)}
-                        fullTitle={getSessionDisplayTitle(session)}
-                        updatedAt={session.updatedAt}
-                        hasUnread={session.hasUnread}
-                        activity={session.activity}
-                        pendingInputType={session.pendingInputType}
-                        status={session.ownership}
-                        provider={session.provider}
-                        executor={session.executor}
-                        isStarred={session.isStarred}
-                        isArchived={session.isArchived}
-                        mode="card"
-                        showContextUsage={false}
-                        isSelected={selectedIds.has(session.id)}
-                        isSelectionMode={isSelectionMode && !isWideScreen}
-                        onNavigate={() => {
-                          // In selection mode on mobile, tap toggles selection
-                          if (isSelectionMode && !isWideScreen) {
-                            handleSelect(
-                              session.id,
-                              !selectedIds.has(session.id),
-                            );
-                          }
-                        }}
-                        onSelect={
-                          isWideScreen || isSelectionMode
-                            ? handleSelect
-                            : undefined
+                      sessionId={session.id}
+                      projectId={session.projectId}
+                      title={getSessionDisplayTitle(session)}
+                      fullTitle={getSessionDisplayTitle(session)}
+                      updatedAt={session.updatedAt}
+                      hasUnread={session.hasUnread}
+                      activity={session.activity}
+                      pendingInputType={session.pendingInputType}
+                      status={session.ownership}
+                      provider={session.provider}
+                      executor={session.executor}
+                      isStarred={session.isStarred}
+                      isArchived={session.isArchived}
+                      mode="card"
+                      showContextUsage={false}
+                      isSelected={selectedIds.has(session.id)}
+                      isSelectionMode={isSelectionMode && !isWideScreen}
+                      onNavigate={() => {
+                        // In selection mode on mobile, tap toggles selection
+                        if (isSelectionMode && !isWideScreen) {
+                          handleSelect(session.id, !selectedIds.has(session.id));
                         }
-                        showProjectName={!projectFilter}
-                        projectName={session.projectName}
-                        basePath={basePath}
-                        messageCount={session.messageCount}
-                        hasDraft={drafts.has(session.id)}
-                      />
-                    </div>
+                      }}
+                      onSelect={
+                        isWideScreen || isSelectionMode
+                          ? handleSelect
+                          : undefined
+                      }
+                      showProjectName={!projectFilter}
+                      projectName={session.projectName}
+                      basePath={basePath}
+                      messageCount={session.messageCount}
+                      hasDraft={drafts.has(session.id)}
+                      itemProps={{
+                        onTouchStart: (e) => handleLongPressStart(session.id, e),
+                        onTouchMove: handleTouchMove,
+                        onTouchEnd: handleLongPressEnd,
+                        onTouchCancel: handleLongPressEnd,
+                        onMouseDown: (e) =>
+                          !isWideScreen && handleLongPressStart(session.id, e),
+                        onMouseUp: handleLongPressEnd,
+                        onMouseLeave: handleLongPressEnd,
+                        onContextMenu: handleContextMenu,
+                      }}
+                    />
                   ))}
                 </ul>
 

--- a/packages/client/src/pages/SessionPage.tsx
+++ b/packages/client/src/pages/SessionPage.tsx
@@ -123,6 +123,7 @@ function SessionPageContent({
     markdownAugments,
     status,
     processState,
+    turnStartedAt,
     isCompacting,
     pendingInputRequest,
     actualSessionId,
@@ -1120,6 +1121,7 @@ function SessionPageContent({
                   isProcessing={
                     status.owner === "self" && processState === "in-turn"
                   }
+                  turnStartedAt={turnStartedAt}
                   isCompacting={isCompacting}
                   scrollTrigger={scrollTrigger}
                   pendingMessages={pendingMessages}

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -8128,7 +8128,7 @@ a.sidebar-nav-item {
 }
 
 .turn-diff-summary {
-  margin-top: var(--space-2);
+  margin-top: var(--space-4);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
@@ -8183,7 +8183,6 @@ a.sidebar-nav-item {
 }
 
 .turn-diff-file-list {
-  margin-top: var(--space-1);
   background: transparent;
 }
 

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -1447,6 +1447,7 @@ a.sidebar-nav-item {
 .session-messages {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: 1rem;
   min-height: 0;
   -webkit-overflow-scrolling: touch;
@@ -1529,6 +1530,10 @@ a.sidebar-nav-item {
     padding-bottom: env(safe-area-inset-bottom, 0px);
   }
 
+  .session-page.keyboard-input-active {
+    padding-bottom: 0;
+  }
+
   .main-content-mobile,
   .main-content-mobile-inner {
     height: 100%;
@@ -1600,6 +1605,13 @@ a.sidebar-nav-item {
   color: var(--text-secondary);
 }
 
+.uploaded-files-metadata {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  width: min(100%, 42rem);
+  gap: var(--space-2);
+}
+
 .uploaded-file-clickable {
   cursor: pointer;
   background: none;
@@ -1611,6 +1623,68 @@ a.sidebar-nav-item {
 
 .uploaded-file-clickable:hover {
   text-decoration: underline;
+}
+
+.uploaded-file-image {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  width: 100%;
+  min-width: 0;
+  padding: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-code) 72%, transparent);
+  text-decoration: none;
+}
+
+.uploaded-file-image:hover {
+  text-decoration: none;
+  border-color: var(--border-color);
+  background: color-mix(in srgb, var(--bg-code) 88%, transparent);
+}
+
+.uploaded-file-image-preview,
+.uploaded-file-image-placeholder {
+  width: 52px;
+  height: 52px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.uploaded-file-image-preview {
+  object-fit: cover;
+  background: var(--bg-secondary);
+}
+
+.uploaded-file-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+  color: var(--text-dimmed);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.uploaded-file-image-meta {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  text-align: left;
+}
+
+.uploaded-file-image-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.uploaded-file-image-size {
+  color: var(--text-dimmed);
+  font-size: 0.7rem;
 }
 
 .uploaded-image-modal {
@@ -1633,6 +1707,8 @@ a.sidebar-nav-item {
   padding-top: var(--space-2);
   border-top: 1px solid var(--border-subtle);
   color: var(--text-secondary);
+  justify-content: flex-start;
+  max-width: 100%;
 }
 
 /* Collapsible text for long user prompts */
@@ -1700,6 +1776,8 @@ a.sidebar-nav-item {
 .assistant-turn {
   position: relative;
   padding-left: 24px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .message-content {
@@ -2527,6 +2605,31 @@ a.sidebar-nav-item {
   font-size: var(--font-size-xs);
 }
 
+.attachment-chip-image {
+  align-items: flex-start;
+  max-width: 168px;
+  padding: 6px;
+  border-radius: 12px;
+}
+
+.attachment-image-preview {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 8px;
+  flex-shrink: 0;
+  background: var(--bg-secondary);
+}
+
+.attachment-image-meta {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 2px;
+}
+
 .attachment-chip.uploading {
   opacity: 0.7;
 }
@@ -2581,6 +2684,16 @@ a.sidebar-nav-item {
   .attachment-chip {
     padding: 2px var(--space-1);
     padding-right: 2px;
+  }
+
+  .attachment-chip-image {
+    max-width: 144px;
+    padding: 5px;
+  }
+
+  .attachment-image-preview {
+    width: 44px;
+    height: 44px;
   }
 }
 
@@ -4118,6 +4231,11 @@ a.sidebar-nav-item {
 
 .session-menu-dropdown button:hover {
   background: var(--bg-hover);
+}
+
+.session-menu-dropdown button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .session-menu-dropdown button svg {

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -8183,6 +8183,7 @@ a.sidebar-nav-item {
 }
 
 .turn-diff-file-list {
+  margin-top: var(--space-1);
   background: transparent;
 }
 

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -1606,8 +1606,8 @@ a.sidebar-nav-item {
 }
 
 .uploaded-files-metadata {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   width: min(100%, 42rem);
   gap: var(--space-2);
 }
@@ -1629,7 +1629,8 @@ a.sidebar-nav-item {
   display: flex;
   align-items: flex-start;
   gap: var(--space-2);
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
   min-width: 0;
   padding: 6px;
   border: 1px solid var(--border-subtle);
@@ -1653,7 +1654,7 @@ a.sidebar-nav-item {
 }
 
 .uploaded-file-image-preview {
-  object-fit: cover;
+  object-fit: contain;
   background: var(--bg-secondary);
 }
 
@@ -1665,26 +1666,6 @@ a.sidebar-nav-item {
   color: var(--text-dimmed);
   font-size: 0.7rem;
   font-weight: 600;
-}
-
-.uploaded-file-image-meta {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 2px;
-  text-align: left;
-}
-
-.uploaded-file-image-name {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--text-primary);
-}
-
-.uploaded-file-image-size {
-  color: var(--text-dimmed);
-  font-size: 0.7rem;
 }
 
 .uploaded-image-modal {
@@ -2615,7 +2596,7 @@ a.sidebar-nav-item {
 .attachment-image-preview {
   width: 56px;
   height: 56px;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: 8px;
   flex-shrink: 0;
   background: var(--bg-secondary);

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -8126,3 +8126,131 @@ a.sidebar-nav-item {
 .git-lines-deleted {
   color: var(--error-color);
 }
+
+.turn-diff-summary {
+  margin-top: var(--space-2);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+  overflow: hidden;
+  font-size: var(--font-size-base);
+  box-shadow: inset 0 1px 0
+    color-mix(in srgb, var(--text-muted) 6%, transparent);
+}
+
+.turn-diff-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 6px 10px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--border-color) 70%, transparent);
+}
+
+.turn-diff-summary-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.turn-diff-summary-title {
+  font-weight: 600;
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.turn-diff-summary-count {
+  color: var(--text-muted);
+}
+
+.turn-diff-total-counts {
+  gap: 0;
+}
+
+.turn-diff-total-counts .git-lines-added,
+.turn-diff-total-counts .git-lines-deleted,
+.turn-diff-line-counts .git-lines-added,
+.turn-diff-line-counts .git-lines-deleted {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 11px;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+}
+
+.turn-diff-file-list {
+  background: transparent;
+}
+
+.turn-diff-file-item {
+  padding: 0;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--border-color) 55%, transparent);
+}
+
+.turn-diff-file-item:last-child {
+  border-bottom: none;
+}
+
+.turn-diff-file-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  font-size: inherit;
+  line-height: 1.25;
+}
+
+.turn-diff-file-button:hover {
+  background: color-mix(in srgb, var(--bg-hover) 80%, transparent);
+}
+
+.turn-diff-path {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  font-size: inherit;
+  color: var(--text-secondary);
+}
+
+.turn-diff-path-directory {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 0 1 auto;
+  color: var(--text-muted);
+}
+
+.turn-diff-path-filename {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+
+.turn-diff-file-button:hover .turn-diff-path-directory,
+.turn-diff-file-button:hover .turn-diff-path-filename {
+  color: var(--text-primary);
+}
+
+.turn-diff-line-counts {
+  margin-left: auto;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  gap: 0;
+  font-size: inherit;
+}

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -1541,10 +1541,17 @@ a.sidebar-nav-item {
 }
 
 /* User prompts - compact bubble that shrinks to fit content */
+.user-prompt-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+
 .message-user-prompt {
   background: var(--bg-user-message);
   border-radius: 6px;
-  margin-left: 0;
+  margin-left: auto;
   width: fit-content;
   max-width: 80%;
   padding: 0.25rem 0.5rem;
@@ -1553,6 +1560,9 @@ a.sidebar-nav-item {
 
 /* Pending messages - waiting for server confirmation */
 .pending-message {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   margin-bottom: var(--space-3);
 }
 
@@ -1571,12 +1581,13 @@ a.sidebar-nav-item {
 .user-prompt-metadata {
   margin-top: var(--space-1);
   margin-bottom: var(--space-3);
-  padding-left: var(--space-2);
+  justify-content: flex-end;
   font-size: var(--font-size-xs);
   color: var(--text-dimmed);
   display: flex;
   gap: var(--space-2);
   flex-wrap: wrap;
+  max-width: 80%;
 }
 
 .opened-file {
@@ -2130,6 +2141,9 @@ a.sidebar-nav-item {
 
 /* Deferred messages - queued server-side */
 .deferred-message {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   margin-bottom: var(--space-3);
 }
 

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -7887,8 +7887,7 @@ a.sidebar-nav-item {
    ========================================================================== */
 
 .session-connection-bar {
-  height: 1px;
-  margin-bottom: 2px;
+  display: none;
   pointer-events: none;
   transition: background-color 0.3s ease;
 }

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -1545,6 +1545,7 @@ a.sidebar-nav-item {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
+  margin-top: calc(var(--space-4) * 4);
   margin-bottom: 1rem;
 }
 

--- a/packages/client/src/styles/renderers.css
+++ b/packages/client/src/styles/renderers.css
@@ -394,16 +394,22 @@
 
 .thinking-block.collapsible {
   margin: var(--space-1) 0;
+  opacity: 0.72;
 }
 
 .collapsible__summary {
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  color: var(--text-muted);
-  font-size: var(--font-size-base);
+  color: color-mix(in srgb, var(--text-muted) 85%, transparent);
+  font-size: var(--font-size-sm);
   cursor: pointer;
   list-style: none;
+}
+
+.thinking-block.collapsible:hover,
+.thinking-block.collapsible[open] {
+  opacity: 0.88;
 }
 
 .collapsible__summary::-webkit-details-marker {
@@ -424,8 +430,8 @@ details[open] .collapsible__icon {
 }
 
 .collapsible__content .text-content {
-  color: var(--text-muted);
-  font-size: var(--font-size-base);
+  color: color-mix(in srgb, var(--text-muted) 82%, transparent);
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   white-space: pre-wrap;
 }

--- a/packages/client/src/styles/tool-rows.css
+++ b/packages/client/src/styles/tool-rows.css
@@ -364,14 +364,16 @@
 }
 
 .operation-segment-toggle.timeline-item::before {
-  top: 50%;
-  transform: translateY(-50%);
+  top: 8px;
   background: var(--timeline-dot-tool);
 }
 
 .operation-segment-toggle.timeline-item.running::before {
+  left: -12px;
+  width: 8px;
+  height: 8px;
   background: var(--timeline-dot-tool);
-  animation: pulse 1.5s ease-in-out infinite;
+  animation: thinking-pulse 1.5s ease-in-out infinite;
 }
 
 .operation-segment-toggle.timeline-item::after {

--- a/packages/client/src/styles/tool-rows.css
+++ b/packages/client/src/styles/tool-rows.css
@@ -369,6 +369,11 @@
   background: var(--timeline-dot-tool);
 }
 
+.operation-segment-toggle.timeline-item.running::before {
+  background: var(--timeline-dot-tool);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
 .operation-segment-toggle.timeline-item::after {
   top: calc(50% + 3px);
 }

--- a/packages/client/src/styles/tool-rows.css
+++ b/packages/client/src/styles/tool-rows.css
@@ -264,6 +264,62 @@
   margin: 2px 0;
 }
 
+.reasoning-segment {
+  margin: 2px 0;
+}
+
+.reasoning-segment-toggle.timeline-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 2px 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-muted) 88%, transparent);
+  text-align: left;
+  cursor: pointer;
+  min-height: 20px;
+  line-height: 1.4;
+}
+
+.reasoning-segment-toggle.timeline-item:hover {
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.reasoning-segment-toggle.timeline-item::before {
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--timeline-dot-thinking, var(--timeline-dot-text));
+}
+
+.reasoning-segment-toggle.timeline-item::after {
+  top: calc(50% + 3px);
+}
+
+.reasoning-segment-label {
+  font-size: calc(var(--font-size-sm) - 1px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(100%, 42rem);
+}
+
+.reasoning-segment-chevron {
+  flex: 0 0 auto;
+  color: inherit;
+  font-size: calc(var(--font-size-sm) - 1px);
+  opacity: 0.7;
+}
+
+.reasoning-segment-content {
+  margin-top: 4px;
+}
+
 .operation-segment-toggle.timeline-item {
   display: flex;
   align-items: center;

--- a/packages/client/src/styles/tool-rows.css
+++ b/packages/client/src/styles/tool-rows.css
@@ -83,7 +83,7 @@
 }
 
 .tool-row.timeline-item.status-complete::before {
-  background: var(--timeline-dot-tool);
+  background: color-mix(in srgb, var(--timeline-dot-tool) 58%, transparent);
 }
 
 .tool-row.timeline-item.status-error::before {
@@ -258,6 +258,64 @@
 
 .tool-row.status-aborted .tool-summary {
   color: var(--text-muted, #888);
+}
+
+.operation-segment {
+  margin: 2px 0;
+}
+
+.operation-segment-toggle.timeline-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 2px 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--text-muted) 82%, transparent);
+  text-align: left;
+  cursor: pointer;
+  opacity: 0.78;
+  min-height: 20px;
+  line-height: 1.4;
+}
+
+.operation-segment-toggle.timeline-item:hover {
+  background: transparent;
+  color: var(--text-muted);
+  opacity: 1;
+}
+
+.operation-segment-toggle.timeline-item::before {
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--timeline-dot-tool);
+}
+
+.operation-segment-toggle.timeline-item::after {
+  top: calc(50% + 3px);
+}
+
+.operation-segment-label {
+  font-size: calc(var(--font-size-sm) - 1px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: min(100%, 42rem);
+}
+
+.operation-segment-chevron {
+  flex: 0 0 auto;
+  color: inherit;
+  font-size: calc(var(--font-size-sm) - 1px);
+  opacity: 0.7;
+}
+
+.operation-segment-content {
+  margin-top: 4px;
 }
 
 .tool-aborted-icon {

--- a/packages/client/src/styles/tool-rows.css
+++ b/packages/client/src/styles/tool-rows.css
@@ -268,6 +268,26 @@
   margin: 2px 0;
 }
 
+.reasoning-progress.timeline-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 20px;
+  padding: 2px 0;
+  color: color-mix(in srgb, var(--text-muted) 88%, transparent);
+  line-height: 1.4;
+}
+
+.reasoning-progress.timeline-item::before {
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--timeline-dot-thinking, var(--timeline-dot-text));
+}
+
+.reasoning-progress.timeline-item::after {
+  top: calc(50% + 3px);
+}
+
 .reasoning-segment-toggle.timeline-item {
   display: flex;
   align-items: center;

--- a/packages/server/src/augments/augment-generator.ts
+++ b/packages/server/src/augments/augment-generator.ts
@@ -23,6 +23,7 @@ import {
   VIDEO_EXTENSIONS,
   isLocalFilePath,
   localFileApiUrl,
+  renderLocalFileLink,
   renderSafeMarkdown,
   sanitizeUrl,
 } from "./safe-markdown.js";
@@ -243,13 +244,12 @@ function renderInlineFormatting(text: string): string {
   result = result.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label, href) => {
     if (isLocalFilePath(href)) {
       const ext = (href.split(".").pop() ?? "").toLowerCase();
-      const apiUrl = escapeHtml(localFileApiUrl(href));
       if (MEDIA_EXTENSIONS.has(ext)) {
+        const apiUrl = escapeHtml(localFileApiUrl(href));
         const mediaType = VIDEO_EXTENSIONS.has(ext) ? "video" : "image";
-        const typeLabel = VIDEO_EXTENSIONS.has(ext) ? "video" : "image";
-        return `<a href="${apiUrl}" class="local-media-link" data-media-type="${mediaType}">${label}<span class="local-media-type">(${typeLabel})</span></a>`;
+        return `<a href="${apiUrl}" class="local-media-link" data-media-type="${mediaType}">${label}<span class="local-media-type">(${mediaType})</span></a>`;
       }
-      return `<a href="${apiUrl}">${label}</a>`;
+      return renderLocalFileLink(href, label);
     }
     const safeHref = sanitizeUrl(href);
     if (!safeHref) {

--- a/packages/server/src/augments/safe-markdown.ts
+++ b/packages/server/src/augments/safe-markdown.ts
@@ -5,6 +5,7 @@ import {
   type Tokens,
 } from "marked";
 import sanitizeHtml from "sanitize-html";
+import { isLikelyFilePath } from "@yep-anywhere/shared";
 
 const ALLOWED_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
 const ALLOWED_IMAGE_PROTOCOLS = new Set(["http:", "https:"]);
@@ -26,15 +27,22 @@ const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "avi", "mkv", "ogv"]);
 const MEDIA_EXTENSIONS = new Set([...IMAGE_EXTENSIONS, ...VIDEO_EXTENSIONS]);
 
 /**
- * Check if a string looks like an absolute local file path.
- * Must start with / (but not //) and contain a file extension.
+ * Check if a string looks like a local file path.
+ * Accepts both absolute paths and repo-relative file paths.
  */
 function isLocalFilePath(href: string): boolean {
   const trimmed = href.trim();
-  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return false;
-  // Must have a file extension after the last /
-  const basename = trimmed.split("/").pop() ?? "";
-  return basename.includes(".");
+  if (!trimmed || trimmed.startsWith("//")) return false;
+  if (/^(?:https?|file|ftp|mailto|tel|data):/i.test(trimmed)) return false;
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../")
+  ) {
+    const basename = trimmed.split("/").pop() ?? "";
+    return basename.includes(".") || isLikelyFilePath(trimmed);
+  }
+  return isLikelyFilePath(trimmed);
 }
 
 /**
@@ -56,6 +64,24 @@ function getFileName(path: string): string {
  */
 function localFileApiUrl(path: string): string {
   return `/api/local-image?path=${encodeURIComponent(path.trim())}`;
+}
+
+function renderLocalFileLink(
+  path: string,
+  label: string,
+  title?: string | null,
+  line?: number,
+): string {
+  const escapedLabel = escapeHtml(label || getFileName(path));
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+  const dataAttrs = [
+    `data-file-path="${escapeHtml(path.trim())}"`,
+    line !== undefined ? `data-line="${line}"` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return `<a href="#" class="file-link local-file-link" ${dataAttrs}${titleAttr}>${escapedLabel}</a>`;
 }
 
 /**
@@ -106,7 +132,14 @@ const MARKDOWN_SANITIZE_OPTIONS = {
     "ul",
   ],
   allowedAttributes: {
-    a: ["href", "title", "class", "data-media-type"],
+    a: [
+      "href",
+      "title",
+      "class",
+      "data-media-type",
+      "data-file-path",
+      "data-line",
+    ],
     code: ["class"],
     img: ["src", "alt", "title"],
     input: ["type", "checked", "disabled"],
@@ -142,10 +175,7 @@ const renderer: RendererObject<string, string> = {
       if (MEDIA_EXTENSIONS.has(ext)) {
         return renderLocalMediaLink(href, renderedText, ext);
       }
-      // Other local file — render as a link to the API
-      const apiUrl = escapeHtml(localFileApiUrl(href));
-      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-      return `<a href="${apiUrl}"${titleAttr}>${renderedText}</a>`;
+      return renderLocalFileLink(href, renderedText, title);
     }
 
     const safeHref = sanitizeUrl(href);
@@ -168,8 +198,7 @@ const renderer: RendererObject<string, string> = {
       if (MEDIA_EXTENSIONS.has(ext)) {
         return renderLocalMediaLink(href, text, ext);
       }
-      // Unrecognized extension — just show text
-      return escapeHtml(text || getFileName(href));
+      return renderLocalFileLink(href, text || getFileName(href), title);
     }
 
     const safeSrc = sanitizeUrl(href, ALLOWED_IMAGE_PROTOCOLS);
@@ -245,4 +274,5 @@ export {
   VIDEO_EXTENSIONS,
   isLocalFilePath,
   localFileApiUrl,
+  renderLocalFileLink,
 };

--- a/packages/server/src/subscriptions.ts
+++ b/packages/server/src/subscriptions.ts
@@ -138,6 +138,9 @@ export function createSessionSubscription(
         case "state-change":
           emit("status", {
             state: event.state.type,
+            ...(event.state.type === "in-turn"
+              ? { turnStartedAt: event.state.since.toISOString() }
+              : {}),
             ...(event.state.type === "waiting-input"
               ? { request: event.state.request }
               : {}),
@@ -187,6 +190,9 @@ export function createSessionSubscription(
     processId: process.id,
     sessionId: process.sessionId,
     state: currentState.type,
+    ...(currentState.type === "in-turn"
+      ? { turnStartedAt: currentState.since.toISOString() }
+      : {}),
     permissionMode: process.permissionMode,
     modeVersion: process.modeVersion,
     provider: process.provider,

--- a/packages/server/src/supervisor/Process.ts
+++ b/packages/server/src/supervisor/Process.ts
@@ -96,7 +96,7 @@ export class Process {
   private legacyQueue: UserMessage[] = [];
   private messageQueue: MessageQueue | null;
   private abortFn: (() => void) | null;
-  private _state: ProcessState = { type: "in-turn" };
+  private _state: ProcessState = { type: "in-turn", since: new Date() };
   private listeners: Set<Listener> = new Set();
   private idleTimer: NodeJS.Timeout | null = null;
   private idleTimeoutMs: number;
@@ -199,6 +199,7 @@ export class Process {
     this.projectPath = options.projectPath;
     this.projectId = options.projectId;
     this.startedAt = new Date();
+    this._state = { type: "in-turn", since: this.startedAt };
     this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
 
     // Real SDK provides these, mock SDK doesn't
@@ -575,7 +576,7 @@ export class Process {
       if (this.iteratorDone) {
         this.transitionToIdle();
       } else {
-        this.setState({ type: "in-turn" });
+        this.setState({ type: "in-turn", since: new Date() });
       }
     }
   }
@@ -950,7 +951,7 @@ export class Process {
       // Transition to running if we were idle
       if (this._state.type === "idle") {
         this.clearIdleTimer();
-        this.setState({ type: "in-turn" });
+        this.setState({ type: "in-turn", since: new Date() });
       }
       // Pass message with UUID so SDK uses the same UUID we emitted via SSE
       const position = this.messageQueue.push(messageWithUuid);
@@ -1289,7 +1290,7 @@ export class Process {
       }
     }
     // No more pending approvals
-    this.setState({ type: "in-turn" });
+    this.setState({ type: "in-turn", since: new Date() });
   }
 
   /**
@@ -1314,7 +1315,7 @@ export class Process {
         this._state.request.id === requestId
       ) {
         // Mock SDK case - just transition back to idle/running
-        this.setState({ type: "in-turn" });
+        this.setState({ type: "in-turn", since: new Date() });
         return true;
       }
       return false;
@@ -1675,7 +1676,7 @@ export class Process {
     if (nextMessage) {
       // In real implementation with MessageQueue, this happens automatically
       // For mock SDK, we just transition back to running
-      this.setState({ type: "in-turn" });
+      this.setState({ type: "in-turn", since: new Date() });
     }
   }
 

--- a/packages/server/src/supervisor/types.ts
+++ b/packages/server/src/supervisor/types.ts
@@ -170,7 +170,7 @@ export interface Session extends SessionSummary {
 
 // Process state machine
 export type ProcessState =
-  | { type: "in-turn" }
+  | { type: "in-turn"; since: Date }
   | { type: "idle"; since: Date }
   | { type: "waiting-input"; request: InputRequest }
   | { type: "hold"; since: Date }

--- a/packages/server/test/augments/safe-markdown.test.ts
+++ b/packages/server/test/augments/safe-markdown.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderSafeMarkdown } from "../../src/augments/safe-markdown.js";
+
+describe("renderSafeMarkdown local file links", () => {
+  it("renders local non-media file links as file links", () => {
+    const html = renderSafeMarkdown("[summary](./tmp/summary.txt)");
+
+    expect(html).toContain('class="file-link local-file-link"');
+    expect(html).toContain('data-file-path="./tmp/summary.txt"');
+    expect(html).not.toContain("/api/local-image");
+  });
+
+  it("keeps local media links pointed at the local-image API", () => {
+    const html = renderSafeMarkdown("[preview](/tmp/screenshot.png)");
+
+    expect(html).toContain('class="local-media-link"');
+    expect(html).toContain("/api/local-image?path=%2Ftmp%2Fscreenshot.png");
+  });
+});


### PR DESCRIPTION
## Summary
- align the session experience more closely with Codex-style interaction patterns by surfacing the most important content first
- reduce visual noise by collapsing non-essential details by default, so agent conversations feel more natural and easier to scan
- add focused message UX improvements including reasoning folds, per-turn diff summaries, inline local file preview, live turn timing, inline uploaded image previews, and cleaner session hierarchy/styling
- include the supporting client and server changes needed to render these interactions safely and consistently

## Interaction Details
- default the reading flow to the assistant's user-facing response, while moving supporting process details into collapsible UI that stays available when needed
- collapse intermediate reasoning, tool-generated metadata, and edit-heavy implementation details unless they add immediate value to the current reading context
- present file changes as a compact per-turn summary first, then let the user drill into the underlying edits only when they want implementation-level detail
- keep local file references in context by opening them inline, so users can inspect referenced files without breaking the conversation flow or losing their place in the session
- render uploaded image attachments as compact inline previews instead of exposing base64-heavy content, and let users expand them in a modal for full-size inspection when needed
- refine uploaded image previews so they preserve the full image inside the thumbnail, reduce metadata clutter in the attachment row, and expose file details through accessible labels and modal titles
- expose elapsed time during active turns to make long-running agent work legible without forcing status noise into the main message content
- refine message hierarchy and spacing so the conversation reads more like a natural chat transcript and less like a raw execution log
- make the expanded state feel intentional: important outcomes remain immediately visible, while operational detail is one click away instead of constantly competing for attention

## Screenshot

### FROM
<img width="953" height="1212" alt="image" src="https://github.com/user-attachments/assets/d30791ea-8bd4-4857-8e5e-dd802854b4a9" />

### TO
<img width="961" height="1082" alt="image" src="https://github.com/user-attachments/assets/93d8409b-4055-4772-a730-7524903fa080" />

<img width="881" height="259" alt="image" src="https://github.com/user-attachments/assets/025c9baa-c636-41e6-9b35-7a40daf4b406" />
<img width="414" height="317" alt="image" src="https://github.com/user-attachments/assets/cbc24e73-4ef9-433a-88a0-348a7907d274" />
