### PR TITLE
Fix desktop webview auth loss on external link navigation

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -18,6 +18,7 @@ import { useOnboarding } from "./hooks/useOnboarding";
 import { useReloadNotifications } from "./hooks/useReloadNotifications";
 import { I18nProvider } from "./i18n";
 import { initClientLogCollection } from "./lib/diagnostics";
+import { installExternalLinkHandler } from "./lib/externalLinks";
 
 interface Props {
   children: ReactNode;
@@ -35,6 +36,10 @@ function AppContent({ children }: Props) {
 
   // Client-side log collection for connection diagnostics
   useEffect(() => initClientLogCollection(), []);
+
+  // In the desktop webview, route external links to the system browser so they
+  // never navigate the app's own webview (which would lose the auth token).
+  useEffect(() => installExternalLinkHandler(), []);
 
   // Sync notifyInApp setting to service worker on app startup and SW restarts
   useSyncNotifyInAppSetting();

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -173,25 +173,55 @@ const API_BASE = "/api";
 /**
  * Desktop auth token read from URL query parameter (?desktop_token=...).
  * When present, sent as X-Desktop-Token header on every API request.
- * The Tauri desktop app passes this token to authenticate the iframe
+ * The Tauri desktop app passes this token to authenticate the webview
  * without cookies or sessions — the token is valid for the server's lifetime.
  */
-let desktopAuthToken: string | null = null;
-if (typeof window !== "undefined") {
+const DESKTOP_TOKEN_STORAGE_KEY = "yep-desktop-token";
+
+/**
+ * Resolve the desktop auth token on load.
+ *
+ * The token arrives once as a URL query param, after which it is stripped from
+ * the URL (so it never lands in history/bookmarks) and persisted to
+ * sessionStorage. Persisting it is what survives a document reload or a
+ * back-navigation: without it, reloading the page re-runs this module with no
+ * token in the URL, which previously bricked the desktop app with 401s.
+ *
+ * sessionStorage (not localStorage) matches the token's lifetime — it lives for
+ * the duration of the webview session and is not carried across app restarts,
+ * which would otherwise leave a stale token for a freshly-minted server.
+ */
+export function resolveDesktopAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+
   const params = new URLSearchParams(window.location.search);
-  const token = params.get("desktop_token");
-  if (token) {
-    desktopAuthToken = token;
-    // Strip token from URL to keep it out of history/bookmarks
+  const urlToken = params.get("desktop_token");
+
+  if (urlToken) {
+    try {
+      window.sessionStorage.setItem(DESKTOP_TOKEN_STORAGE_KEY, urlToken);
+    } catch {
+      // sessionStorage may be unavailable; in-memory token still works.
+    }
+    // Strip token from URL to keep it out of history/bookmarks.
     params.delete("desktop_token");
     const cleanUrl = params.toString()
       ? `${window.location.pathname}?${params.toString()}${window.location.hash}`
       : `${window.location.pathname}${window.location.hash}`;
     window.history.replaceState({}, "", cleanUrl);
+    return urlToken;
+  }
+
+  try {
+    return window.sessionStorage.getItem(DESKTOP_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
   }
 }
 
-/** Get the desktop auth token (if running inside Tauri iframe). */
+const desktopAuthToken: string | null = resolveDesktopAuthToken();
+
+/** Get the desktop auth token (if running inside Tauri webview). */
 export function getDesktopAuthToken(): string | null {
   return desktopAuthToken;
 }

--- a/packages/client/src/api/desktopToken.test.ts
+++ b/packages/client/src/api/desktopToken.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveDesktopAuthToken } from "./client";
+
+describe("resolveDesktopAuthToken", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    window.sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("reads the token from the URL and strips it", () => {
+    window.history.replaceState({}, "", "/?desktop_token=abc123");
+    const token = resolveDesktopAuthToken();
+    expect(token).toBe("abc123");
+    // Token removed from the visible URL.
+    expect(window.location.search).not.toContain("desktop_token");
+  });
+
+  it("persists the token so a later reload (no URL param) still finds it", () => {
+    // First load: token in URL.
+    window.history.replaceState({}, "", "/?desktop_token=abc123");
+    expect(resolveDesktopAuthToken()).toBe("abc123");
+
+    // Simulate a document reload / back-navigation: URL has no token anymore.
+    window.history.replaceState({}, "", "/sessions/42");
+    expect(resolveDesktopAuthToken()).toBe("abc123");
+  });
+
+  it("preserves other query params when stripping the token", () => {
+    window.history.replaceState({}, "", "/?desktop_token=abc123&foo=bar");
+    resolveDesktopAuthToken();
+    expect(window.location.search).toContain("foo=bar");
+    expect(window.location.search).not.toContain("desktop_token");
+  });
+
+  it("returns null when no token has ever been provided", () => {
+    expect(resolveDesktopAuthToken()).toBeNull();
+  });
+});

--- a/packages/client/src/lib/externalLinks.test.ts
+++ b/packages/client/src/lib/externalLinks.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installExternalLinkHandler } from "./externalLinks";
+
+describe("installExternalLinkHandler", () => {
+  let invoke: ReturnType<typeof vi.fn>;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    invoke = vi.fn().mockResolvedValue(undefined);
+    // biome-ignore lint/suspicious/noExplicitAny: simulating Tauri-injected global
+    (window as any).__TAURI_INTERNALS__ = { invoke };
+    cleanup = installExternalLinkHandler();
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+    (window as any).__TAURI_INTERNALS__ = undefined;
+    vi.restoreAllMocks();
+  });
+
+  function clickAnchor(href: string): MouseEvent {
+    const a = document.createElement("a");
+    a.href = href;
+    a.textContent = "link";
+    document.body.appendChild(a);
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    a.dispatchEvent(event);
+    return event;
+  }
+
+  it("intercepts external http(s) links and opens them via the opener", () => {
+    const event = clickAnchor("https://example.com/page");
+    expect(event.defaultPrevented).toBe(true);
+    expect(invoke).toHaveBeenCalledWith("plugin:opener|open_url", {
+      url: "https://example.com/page",
+    });
+  });
+
+  it("ignores same-origin links so in-app navigation still works", () => {
+    const event = clickAnchor(`${window.location.origin}/sessions/123`);
+    expect(event.defaultPrevented).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("ignores anchors without an href", () => {
+    const a = document.createElement("a");
+    a.textContent = "no href";
+    document.body.appendChild(a);
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    a.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("does nothing outside Tauri", () => {
+    cleanup();
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+    (window as any).__TAURI_INTERNALS__ = undefined;
+    cleanup = installExternalLinkHandler();
+    const event = clickAnchor("https://example.com/page");
+    expect(event.defaultPrevented).toBe(false);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/lib/externalLinks.ts
+++ b/packages/client/src/lib/externalLinks.ts
@@ -1,0 +1,46 @@
+/**
+ * Global handler that keeps external links from navigating the desktop webview.
+ *
+ * In the Tauri desktop app the webview points directly at the local server's
+ * web UI. A plain `<a href="https://...">` click (e.g. a link in a chat
+ * message) performs a top-level navigation, replacing the app with the external
+ * page. Navigating back then reloads the document without the in-memory desktop
+ * auth token, bricking the UI with 401s. To avoid this, external http(s) links
+ * are opened in the system browser and the in-app navigation is cancelled.
+ *
+ * No-op outside Tauri — regular browsers handle links natively.
+ */
+import { isTauri, openExternalUrl } from "./tauri";
+
+function isExternalHttpLink(anchor: HTMLAnchorElement): boolean {
+  // anchor.href is always absolute; protocol/origin are resolved by the DOM.
+  if (anchor.protocol !== "http:" && anchor.protocol !== "https:") {
+    return false;
+  }
+  return anchor.origin !== window.location.origin;
+}
+
+export function installExternalLinkHandler(): () => void {
+  if (!isTauri()) {
+    return () => {};
+  }
+
+  const onClick = (event: MouseEvent) => {
+    // Respect modifier-click and non-primary buttons handled elsewhere.
+    if (event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    const target = event.target as Element | null;
+    const anchor = target?.closest("a");
+    if (!anchor?.getAttribute("href")) return;
+    if (!isExternalHttpLink(anchor)) return;
+
+    event.preventDefault();
+    void openExternalUrl(anchor.href);
+  };
+
+  document.addEventListener("click", onClick);
+  return () => document.removeEventListener("click", onClick);
+}

--- a/packages/client/src/lib/tauri.test.ts
+++ b/packages/client/src/lib/tauri.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isTauri, openExternalUrl } from "./tauri";
+
+describe("isTauri", () => {
+  afterEach(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup of injected globals
+    (window as any).__TAURI_INTERNALS__ = undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup of injected globals
+    (window as any).__TAURI__ = undefined;
+  });
+
+  it("returns false in a normal browser", () => {
+    expect(isTauri()).toBe(false);
+  });
+
+  it("returns true when Tauri internals are injected", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: simulating Tauri-injected global
+    (window as any).__TAURI_INTERNALS__ = { invoke: () => {} };
+    expect(isTauri()).toBe(true);
+  });
+});
+
+describe("openExternalUrl", () => {
+  let invoke: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    invoke = vi.fn().mockResolvedValue(undefined);
+    // biome-ignore lint/suspicious/noExplicitAny: simulating Tauri-injected global
+    (window as any).__TAURI_INTERNALS__ = { invoke };
+  });
+
+  afterEach(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+    (window as any).__TAURI_INTERNALS__ = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("opens via the Tauri opener plugin", async () => {
+    await openExternalUrl("https://example.com");
+    expect(invoke).toHaveBeenCalledWith("plugin:opener|open_url", {
+      url: "https://example.com",
+    });
+  });
+
+  it("falls back to window.open if the opener invoke fails", async () => {
+    invoke.mockRejectedValueOnce(new Error("no permission"));
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+    await openExternalUrl("https://example.com");
+    expect(open).toHaveBeenCalledWith(
+      "https://example.com",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+});

--- a/packages/client/src/lib/tauri.ts
+++ b/packages/client/src/lib/tauri.ts
@@ -1,0 +1,52 @@
+/**
+ * Tauri detection and helpers for the web client.
+ *
+ * The web UI (this package) runs inside the Tauri desktop webview, but it is
+ * served by the local server — the `@tauri-apps/api` package is NOT bundled
+ * here. We therefore detect Tauri and talk to its plugins through the globals
+ * Tauri injects into the webview (`window.__TAURI_INTERNALS__`).
+ */
+
+interface TauriInternals {
+  invoke: (cmd: string, args?: Record<string, unknown>) => Promise<unknown>;
+}
+
+declare global {
+  interface Window {
+    __TAURI_INTERNALS__?: TauriInternals;
+    /** Present when withGlobalTauri is enabled; used only as a fallback signal. */
+    __TAURI__?: unknown;
+  }
+}
+
+/** True when running inside the Tauri desktop webview. */
+export function isTauri(): boolean {
+  if (typeof window === "undefined") return false;
+  return (
+    window.__TAURI_INTERNALS__ !== undefined || window.__TAURI__ !== undefined
+  );
+}
+
+/**
+ * Open a URL in the user's default system browser via the Tauri opener plugin.
+ *
+ * Falls back to `window.open` if the plugin invoke is unavailable or fails, so
+ * a misconfigured permission never leaves the link completely dead.
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+  const internals =
+    typeof window !== "undefined" ? window.__TAURI_INTERNALS__ : undefined;
+
+  if (internals?.invoke) {
+    try {
+      await internals.invoke("plugin:opener|open_url", { url });
+      return;
+    } catch {
+      // Fall through to window.open below.
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}


### PR DESCRIPTION
## Summary

In the Tauri desktop app, the webview points directly at the local server's web UI (`MainLayout.tsx` does `window.location.href = http://localhost:PORT/?desktop_token=…`). Because chat/markdown links render as bare `<a href="https://…">` with no `target`, clicking one performed a **top-level navigation** that replaced the app with the external page. Pressing **Back** then reloaded the document — but the desktop auth token had already been stripped from the URL and only lived in an in-memory module variable, so the reloaded page had no token. Every API and WebSocket request then returned **401 Unauthorized**, and the only recovery was to fully kill and relaunch the app.

This fixes it with defense-in-depth at two layers:

1. **External links open in the system browser.** A global click handler (active only inside the Tauri webview) routes cross-origin `http(s)` links to the OS browser via the `tauri-plugin-opener` plugin and cancels the in-app navigation. Same-origin links are left untouched, so SPA routing still works.
2. **The desktop auth token survives reloads.** The token is now persisted to `sessionStorage` on first load and re-read on subsequent loads, so even if some navigation reloads the document, the session re-hydrates instead of going dead. `sessionStorage` (not `localStorage`) matches the token's lifetime — it's scoped to the webview session and won't carry a stale token into a freshly-launched server.

## Changes

- `packages/client/src/lib/tauri.ts` (new) — `isTauri()` detection and `openExternalUrl()` via the opener plugin (with a `window.open` fallback). Talks to Tauri through the injected `window.__TAURI_INTERNALS__` global, since `@tauri-apps/api` is not bundled into the server-served client.
- `packages/client/src/lib/externalLinks.ts` (new) — global external-link click interceptor; no-op outside Tauri.
- `packages/client/src/api/client.ts` — extracted `resolveDesktopAuthToken()` which persists/re-reads the token via `sessionStorage`.
- `packages/client/src/App.tsx` — installs the link handler once on startup.
- Tests for all three units.

## Test plan

- [x] `tsc --noEmit` (client) — clean
- [x] `biome lint` on changed files — clean
- [x] New unit tests pass: `tauri.test.ts`, `externalLinks.test.ts`, `desktopToken.test.ts` (12 tests)
- [x] Full client suite green (1 pre-existing, unrelated failure in `ToolCallRow.preview-height.test.ts` confirmed present on `main`)
- [x] **Native desktop build compiles** — installed the Rust toolchain and ran `cargo build` on `packages/desktop/src-tauri`; finished with exit 0, linking `tauri-plugin-opener` (confirms the `plugin:opener|open_url` IPC command this code calls exists in the built binary).
- [x] **Bug reproduced against the real server** — ran the server with `DESKTOP_AUTH_TOKEN` set (as the Tauri sidecar does): `/api/sessions` without the token → **401** (the bricked state), with `X-Desktop-Token` → **200**, wrong token → 401.
- [x] **Fix verified behaviorally in real Chrome** — drove the actual source modules via Vite + Playwright, simulating the Tauri webview: `isTauri()` detects the webview; `openExternalUrl()` invokes `plugin:opener|open_url`; an external link click is routed to the opener and the navigation is cancelled; a same-origin link is left untouched (in-app nav preserved); the auth token survives a simulated reload via `sessionStorage`.
- [x] **Causation confirmed via control** — reproducing the old in-memory-only logic in the same browser yields `firstLoad=<token>`, `afterReload=null` (bricked); the new `resolveDesktopAuthToken()` returns the token after reload.

## Notes

The only step not exercised end-to-end is the OS handing the diverted URL to the default browser through a visible desktop window — that runs in the `tauri-plugin-opener` plugin (which the build confirms is linked and registered), not in this code. Everything up to that boundary is verified above.