### PR TITLE
Fix horizontal page scroll on mobile chat view

### DIFF
--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -1762,9 +1762,11 @@ a.sidebar-nav-item {
 .session-messages {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   scrollbar-gutter: stable;
   padding: 1rem;
   min-height: 0;
+  min-width: 0;
   -webkit-overflow-scrolling: touch;
   /* Softly fade the bottom few px of scrolling content into the composer,
      so text doesn't hard-cut right above the connection bar. */
@@ -2546,6 +2548,7 @@ a.sidebar-nav-item {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
 }
 
 .session-btw-pane {
@@ -2797,6 +2800,7 @@ a.sidebar-nav-item {
   width: 100%;
   max-width: var(--content-max-width);
   margin: 0 auto;
+  min-width: 0;
 }
 
 /* Mobile-specific adjustments */


### PR DESCRIPTION
## Problem

On mobile, the chat/session view scrolls **horizontally** whenever a message contains wide content — long code blocks, or the `Ran <command>` tool-output rows. The whole page shifts sideways (header and text included), which is disorienting and serves no purpose. Desktop is unaffected.

## Root cause

`.session-messages` (the vertical scroll container) sets `overflow-y: auto` but leaves `overflow-x` at its default. Per the CSS overflow spec, when one axis is `auto`, a computed `visible` on the other axis becomes **`auto`** — so horizontal scrolling was silently enabled on the messages area.

The desktop layout already avoids this: the `@media (min-width: 1100px)` block sets `overflow-x: hidden` and `min-width: 0` on the same containers. But the **base** rules — the ones that apply on mobile — never got those constraints.

## Fix

Pull the constraints the desktop media query already relies on down into the base rules (`packages/client/src/styles/index.css`):

- `.session-messages` → add `overflow-x: hidden` + `min-width: 0`
- `.session-split` → add `min-width: 0` (let flex children shrink instead of expanding the layout)
- `.main-content-mobile-inner .session-messages .message-list` → add `min-width: 0`

Wide code blocks keep their own `overflow-x: auto`, so they now scroll **within their own box** instead of widening the entire page. No desktop behavior changes (the existing `min-width: 1100px` overrides are unaffected).

4 lines added, CSS-only. Verified on a real device build.

---

I run a small fork with a few local additions, but this is a clean, isolated fix branched off `main`, so I figured it was worth sending upstream. Happy to attach a before/after screenshot if useful.
