### PR TITLE
fix: close modals on mobile back gesture instead of navigating away

### DIFF
--- a/packages/client/src/components/AttachmentChip.tsx
+++ b/packages/client/src/components/AttachmentChip.tsx
@@ -350,7 +350,7 @@ function ImageAttachmentChip({
           document.body,
         )}
       {showModal && (
-        <Modal title={originalName} onClose={() => setShowModal(false)}>
+        <Modal title={originalName} onClose={() => setShowModal(false)} backCloses>
           <div className="uploaded-image-modal">
             {loading && <div className="image-loading">Loading...</div>}
             {error && <div className="image-error">Failed to load image</div>}

--- a/packages/client/src/components/CodexUpdatePrompt.tsx
+++ b/packages/client/src/components/CodexUpdatePrompt.tsx
@@ -132,7 +132,7 @@ export function CodexUpdatePrompt() {
         : null);
 
   return (
-    <Modal title="Codex CLI update available" onClose={handleModalClose}>
+    <Modal title="Codex CLI update available" onClose={handleModalClose} backCloses>
       <div className="settings-group codex-update-prompt">
         <p className="codex-update-prompt__summary">
           {installSucceeded

--- a/packages/client/src/components/FilePathLink.tsx
+++ b/packages/client/src/components/FilePathLink.tsx
@@ -1,5 +1,5 @@
 import { fromUrlProjectId, isUrlProjectId } from "@yep-anywhere/shared";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   buildPublicShareFileHref,
@@ -234,9 +234,48 @@ export function FileViewerModal({
   openInNewTabUrl?: string | null;
   onClose: () => void;
 }) {
+  // Back gesture closes modal: pushes a history entry on open; popstate
+  // closes the modal instead of navigating away from the session.
+  // Uses refs for onClose to avoid stale closure issues.
+  const pushedRef = useRef(false);
+  const closingViaPopstateRef = useRef(false);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    window.history.pushState({ __fileViewer: true }, "");
+    pushedRef.current = true;
+    const handlePopState = () => {
+      // popstate event.state is the entry we navigated TO, not the one we
+      // left. Check our own ref instead to know if we pushed an entry.
+      if (pushedRef.current) {
+        closingViaPopstateRef.current = true;
+        pushedRef.current = false;
+        onCloseRef.current();
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+
+  // Wrapped close: removes the pushed history entry on manual close, then
+  // calls the parent onClose.
+  const close = useCallback(() => {
+    if (pushedRef.current) {
+      pushedRef.current = false;
+      if (!closingViaPopstateRef.current) {
+        window.history.back();
+      }
+      closingViaPopstateRef.current = false;
+    }
+    onCloseRef.current();
+  }, []);
+
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
-      onClose();
+      close();
     }
   };
 
@@ -246,36 +285,12 @@ export function FileViewerModal({
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
-        onClose();
+        close();
       }
     };
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [onClose]);
-
-  // Make the back gesture (mobile edge-swipe or browser Back) close this
-  // pane instead of navigating the underlying session route back to the
-  // session list. Push a history entry on open; popping it (via Back) fires
-  // popstate, which we translate into onClose. The pushed entry keeps the
-  // same URL, so the router does not actually change routes. Closing via the
-  // X or Escape pops our own entry so history does not keep a dead state.
-  useEffect(() => {
-    const priorState =
-      typeof window !== "undefined" ? window.history.state : null;
-    window.history.pushState({ ...priorState, __fileViewerModal: true }, "");
-    let closedByPop = false;
-    const handlePopState = () => {
-      closedByPop = true;
-      onClose();
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-      if (!closedByPop) {
-        window.history.back();
-      }
-    };
-  }, [onClose]);
+  }, [close]);
 
   // Prevent body scroll when modal is open
   useEffect(() => {
@@ -309,7 +324,7 @@ export function FileViewerModal({
           viewMode={viewMode}
           source={source}
           openInNewTabUrl={openInNewTabUrl}
-          onClose={onClose}
+          onClose={close}
         />
       </dialog>
     </div>

--- a/packages/client/src/components/FileViewer.tsx
+++ b/packages/client/src/components/FileViewer.tsx
@@ -877,6 +877,7 @@ export const FileViewer = memo(function FileViewer({
         <Modal
           title={getPathBasename(projectFileModal.filePath)}
           onClose={closeProjectFileModal}
+          backCloses
         >
           <FileViewer
             projectId={projectFileModal.projectId}

--- a/packages/client/src/components/LocalMediaModal.tsx
+++ b/packages/client/src/components/LocalMediaModal.tsx
@@ -411,7 +411,7 @@ export function LocalMediaModal({
   }, [mediaSource, path]);
 
   return (
-    <Modal title={fileName} onClose={onClose}>
+    <Modal title={fileName} onClose={onClose} backCloses>
       <div className="local-media-modal-content">
         {loading && <div className="local-media-loading">Loading...</div>}
         {error && <div className="local-media-error">{error}</div>}
@@ -494,7 +494,7 @@ export function LocalFileModal({ resource, onClose }: LocalFileModalProps) {
   }, [apiPath]);
 
   return (
-    <Modal title={fileName} onClose={onClose}>
+    <Modal title={fileName} onClose={onClose} backCloses>
       <div className="local-file-modal-content">
         <div
           className="local-file-modal-meta"

--- a/packages/client/src/components/ProcessInfoModal.tsx
+++ b/packages/client/src/components/ProcessInfoModal.tsx
@@ -506,7 +506,7 @@ export function ProcessInfoBody({
 export function ProcessInfoModal({ onClose, ...rest }: ProcessInfoModalProps) {
   const { t } = useI18n();
   return (
-    <Modal title={t("processInfoTitle")} onClose={onClose}>
+    <Modal title={t("processInfoTitle")} onClose={onClose} backCloses>
       <ProcessInfoBody {...rest} />
     </Modal>
   );

--- a/packages/client/src/components/RiskAffordance.tsx
+++ b/packages/client/src/components/RiskAffordance.tsx
@@ -36,7 +36,7 @@ export function RiskAffordance({
         {explanation}
       </div>
       {showModal && (
-        <Modal title={modalTitle} onClose={() => setShowModal(false)}>
+        <Modal title={modalTitle} onClose={() => setShowModal(false)} backCloses>
           {explanation}
         </Modal>
       )}

--- a/packages/client/src/components/SchemaWarning.tsx
+++ b/packages/client/src/components/SchemaWarning.tsx
@@ -128,6 +128,7 @@ export function SchemaWarning({ toolName, errors }: SchemaWarningProps) {
             </span>
           }
           onClose={handleClose}
+          backCloses
         >
           <div className="schema-warning-modal-content">
             {missing.length > 0 && (

--- a/packages/client/src/components/SessionHeartbeatModal.tsx
+++ b/packages/client/src/components/SessionHeartbeatModal.tsx
@@ -311,7 +311,7 @@ export function SessionHeartbeatModal({
   );
 
   return (
-    <Modal title={t("sessionHeartbeatTitle")} onClose={onClose}>
+    <Modal title={t("sessionHeartbeatTitle")} onClose={onClose} backCloses>
       <div
         className="settings-group session-heartbeat-modal"
       >

--- a/packages/client/src/components/SessionShareModal.tsx
+++ b/packages/client/src/components/SessionShareModal.tsx
@@ -243,6 +243,7 @@ export function SessionShareModal({
       anchorRect={anchorRect}
       title={t("sessionShareTitle")}
       onClose={onClose}
+      backCloses
     >
       <div className="session-share-modal">
         <p className="session-share-readonly-note">

--- a/packages/client/src/components/ToolApprovalPanel.tsx
+++ b/packages/client/src/components/ToolApprovalPanel.tsx
@@ -289,6 +289,7 @@ export function ToolApprovalPanel({
                       tool: displayToolName ?? request.toolName,
                     })}
                     onClose={() => setShowPreviewModal(false)}
+                    backCloses
                   >
                     <div className="tool-use-expanded">
                       {toolRegistry.renderToolUse(

--- a/packages/client/src/components/renderers/tools/BashRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/BashRenderer.tsx
@@ -684,6 +684,7 @@ function BashCollapsedPreview({
         <Modal
           title={input.description || "Bash Command"}
           onClose={handleClose}
+          backCloses
         >
           <BashModalContent input={input} result={result} isError={isError} />
         </Modal>

--- a/packages/client/src/components/renderers/tools/EditRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/EditRenderer.tsx
@@ -960,6 +960,7 @@ function EditCollapsedPreview({
               />
             }
             onClose={handleClose}
+            backCloses
           >
             <DiffModalContent
               diffHtml={diffHtml}
@@ -1016,6 +1017,7 @@ function EditCollapsedPreview({
                 <EditModalTitle filePath={filePath} displayText={fileName} />
               }
               onClose={handleClose}
+              backCloses
             >
               <RawPatchModalContent
                 rawPatch={rawPatch}
@@ -1082,6 +1084,7 @@ function EditCollapsedPreview({
             />
           }
           onClose={handleClose}
+          backCloses
         >
           <DiffModalContent
             diffHtml={diffHtml}
@@ -1183,6 +1186,7 @@ function EditInteractiveSummary({
               <EditModalTitle filePath={filePath} displayText={fileName} />
             }
             onClose={() => setShowModal(false)}
+            backCloses
           >
             <div className="diff-modal-content">
               <div className="diff-context-controls">
@@ -1239,6 +1243,7 @@ function EditInteractiveSummary({
             />
           }
           onClose={() => setShowModal(false)}
+          backCloses
         >
           <DiffModalContent
             diffHtml={diffHtml}
@@ -1429,6 +1434,7 @@ function EditToolResult({
               />
             }
             onClose={() => setShowModal(false)}
+            backCloses
           >
             <DiffModalContent
               diffHtml={inputWithAugment._diffHtml}
@@ -1529,6 +1535,7 @@ function EditToolResult({
             />
           }
           onClose={() => setShowModal(false)}
+          backCloses
         >
           <DiffModalContent
             structuredPatch={result.structuredPatch}

--- a/packages/client/src/components/renderers/tools/GrepRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/GrepRenderer.tsx
@@ -153,7 +153,7 @@ function GrepMatchDrilldown({
         {label}
       </button>
       {showModal && (
-        <Modal title={label} onClose={() => setShowModal(false)}>
+        <Modal title={label} onClose={() => setShowModal(false)} backCloses>
           <div className="grep-match-modal">
             <table className="grep-match-table">
               <thead>

--- a/packages/client/src/components/renderers/tools/ViewImageRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/ViewImageRenderer.tsx
@@ -94,7 +94,7 @@ function ViewImageClickable({
         }}
       />
       {showModal && (
-        <Modal title={fileName} onClose={() => setShowModal(false)}>
+        <Modal title={fileName} onClose={() => setShowModal(false)} backCloses>
           <ViewImageModalContent path={path} alt={fileName} />
         </Modal>
       )}

--- a/packages/client/src/components/renderers/tools/WriteRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/WriteRenderer.tsx
@@ -435,6 +435,7 @@ function WriteCollapsedPreview({
             </span>
           }
           onClose={handleClose}
+          backCloses
         >
           <WriteModalContent
             file={

--- a/packages/client/src/components/renderers/tools/WriteStdinRenderer.tsx
+++ b/packages/client/src/components/renderers/tools/WriteStdinRenderer.tsx
@@ -204,6 +204,7 @@ function ReadViaPtyFile({
         <Modal
           title={<span className="file-path">{fileName}</span>}
           onClose={() => setShowModal(false)}
+          backCloses
         >
           <div className="file-content-modal">
             <div className="file-content-with-lines">

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -1,6 +1,7 @@
 import {
   type CSSProperties,
   type ReactNode,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -26,6 +27,12 @@ interface ModalProps {
   children: ReactNode;
   onClose: () => void;
   anchorRect?: ModalAnchorRect | null;
+  /**
+   * When true, the browser's back gesture (swipe back on mobile) closes the
+   * modal instead of navigating away from the page. Opens by pushing a
+   * history entry and closes on popstate.
+   */
+  backCloses?: boolean;
 }
 
 /**
@@ -33,16 +40,58 @@ interface ModalProps {
  * Renders via portal to avoid event bubbling issues.
  * Closes on Escape key or clicking the overlay.
  */
-export function Modal({ title, children, onClose, anchorRect }: ModalProps) {
+export function Modal({ title, children, onClose, anchorRect, backCloses }: ModalProps) {
   const { t } = useI18n();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const overlayPointerStartedOnOverlayRef = useRef(false);
+  const backClosesPushedRef = useRef(false);
+  const closingViaPopstateRef = useRef(false);
   const isAnchored =
     !!anchorRect &&
     typeof window !== "undefined" &&
     window.innerWidth > ANCHORED_MODAL_MIN_VIEWPORT_WIDTH_PX;
   const [anchorStyle, setAnchorStyle] = useState<CSSProperties | null>(null);
+
+  // Cache onClose in a ref so the pushState effect doesn't re-run on
+  // reference change (e.g. inline arrow functions on every render).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Back gesture closes modal: pushes a history entry on open; popstate
+  // closes the modal instead of navigating away from the page.
+  useEffect(() => {
+    if (!backCloses) return;
+    window.history.pushState({ __modal: true }, "");
+    backClosesPushedRef.current = true;
+
+    const handlePopState = () => {
+      // popstate event.state is the entry we navigated TO, not the one we
+      // left. Check our own ref instead to know if we pushed an entry.
+      if (backClosesPushedRef.current) {
+        closingViaPopstateRef.current = true;
+        backClosesPushedRef.current = false;
+        onCloseRef.current();
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [backCloses]);
+
+  // Wrapped close: removes the pushed history entry on manual close, then
+  // calls the parent onClose.
+  const close = useCallback(() => {
+    if (backCloses && backClosesPushedRef.current) {
+      backClosesPushedRef.current = false;
+      if (!closingViaPopstateRef.current) {
+        window.history.back();
+      }
+      closingViaPopstateRef.current = false;
+    }
+    onCloseRef.current();
+  }, [backCloses]);
 
   // Close on Escape key
   useEffect(() => {
@@ -50,12 +99,12 @@ export function Modal({ title, children, onClose, anchorRect }: ModalProps) {
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
-        onClose();
+        close();
       }
     };
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [onClose]);
+  }, [close]);
 
   // Prevent body scroll when modal is open
   useEffect(() => {
@@ -130,7 +179,7 @@ export function Modal({ title, children, onClose, anchorRect }: ModalProps) {
     ) {
       e.preventDefault();
       e.stopPropagation();
-      onClose();
+      close();
     }
     overlayPointerStartedOnOverlayRef.current = false;
   };
@@ -172,7 +221,7 @@ export function Modal({ title, children, onClose, anchorRect }: ModalProps) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onClose();
+              close();
             }}
             aria-label={t("modalClose")}
           >

--- a/packages/client/src/components/ui/Modal.tsx
+++ b/packages/client/src/components/ui/Modal.tsx
@@ -13,6 +13,17 @@ import { useI18n } from "../../i18n";
 const ANCHORED_MODAL_MARGIN_PX = 8;
 const ANCHORED_MODAL_MIN_VIEWPORT_WIDTH_PX = 600;
 
+/**
+ * Global stack of backCloses modal IDs, ordered by open time.
+ * Only the topmost (last) modal responds to popstate so a single back gesture
+ * closes one modal at a time even when modals are nested.
+ *
+ * 全局 backCloses modal 的 ID 栈，按打开顺序排列。只有栈顶（最后一个）modal
+ * 响应 popstate，确保嵌套 modal 时一次返回手势只关闭一层。
+ */
+let modalIdSeq = 0;
+const modalStack: number[] = [];
+
 export interface ModalAnchorRect {
   bottom: number;
   height: number;
@@ -45,6 +56,9 @@ export function Modal({ title, children, onClose, anchorRect, backCloses }: Moda
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const overlayPointerStartedOnOverlayRef = useRef(false);
+  // Unique id for this modal instance in the global backCloses stack.
+  // 当前 modal 实例在全局 backCloses 栈中的唯一标识。
+  const modalIdRef = useRef<number | null>(null);
   const backClosesPushedRef = useRef(false);
   const closingViaPopstateRef = useRef(false);
   const isAnchored =
@@ -60,23 +74,57 @@ export function Modal({ title, children, onClose, anchorRect, backCloses }: Moda
 
   // Back gesture closes modal: pushes a history entry on open; popstate
   // closes the modal instead of navigating away from the page.
+  // Uses a global modal stack so only the topmost backCloses modal responds
+  // to a single back gesture, even when modals are nested.
+  //
+  // 移动端返回手势关闭 modal：打开时 push 一个 history entry，popstate 时关闭
+  // modal 而不是离开页面。使用全局 modal 栈确保嵌套 modal 时一次返回只关闭一层。
   useEffect(() => {
     if (!backCloses) return;
+
+    const modalId = ++modalIdSeq;
+    modalIdRef.current = modalId;
+    modalStack.push(modalId);
     window.history.pushState({ __modal: true }, "");
     backClosesPushedRef.current = true;
 
     const handlePopState = () => {
-      // popstate event.state is the entry we navigated TO, not the one we
-      // left. Check our own ref instead to know if we pushed an entry.
-      if (backClosesPushedRef.current) {
+      // Only the topmost modal in the stack responds to popstate.
+      // popstate event.state 是导航到的 entry，不是离开的 entry。
+      // 用 ref 确认本实例 push 过 entry，且栈顶是当前 modal。
+      if (
+        backClosesPushedRef.current &&
+        modalStack.length > 0 &&
+        modalStack[modalStack.length - 1] === modalId
+      ) {
         closingViaPopstateRef.current = true;
         backClosesPushedRef.current = false;
+        // Remove from stack before calling onClose so the parent
+        // modal (if any) becomes the new top.
+        // 在调用 onClose 前从栈中移除，让父 modal 成为新的栈顶。
+        const idx = modalStack.indexOf(modalId);
+        if (idx >= 0) modalStack.splice(idx, 1);
         onCloseRef.current();
       }
     };
     window.addEventListener("popstate", handlePopState);
     return () => {
       window.removeEventListener("popstate", handlePopState);
+      // Clean up: remove from global stack and clear any pushed history
+      // entry that may have been left behind (e.g. child closed via a
+      // non-Modal close path like a toolbar button).
+      //
+      // 清理：从全局栈中移除，并清理可能残留的 history entry
+      // （例如子 modal 通过非 Modal 关闭路径关闭，如工具栏按钮）。
+      const idx = modalStack.indexOf(modalId);
+      if (idx >= 0) modalStack.splice(idx, 1);
+      if (backClosesPushedRef.current) {
+        backClosesPushedRef.current = false;
+        if (!closingViaPopstateRef.current) {
+          window.history.back();
+        }
+        closingViaPopstateRef.current = false;
+      }
     };
   }, [backCloses]);
 


### PR DESCRIPTION
## Summary

Mobile swipe-back (Android system back) previously navigated away from the session page when a file viewer, diff, or command output modal was open. Now the back gesture closes only the modal, keeping the user on the page.

## Problem

When a user tapped a file path, diff, or command output in a conversation, the modal would open as an overlay. On Android, the system back gesture would navigate the entire page away from the session instead of closing the modal. This caused two issues:

1. **File/diff viewer**: Swipe-back reloaded the page, losing scroll position
2. **Command output**: Swipe-back returned to the previous page instead of staying on the conversation

## Root Cause

The `popstate` event's `event.state` is the state of the entry we navigated **TO**, not the one we left. The previous code checked `event.state?.__fileViewer` to decide whether to close, but this check always failed because `event.state` belonged to the React Router entry underneath, not the pushed modal entry.

## Fix

- Added a `backCloses` opt-in prop to the shared `Modal` component
- When enabled, the modal pushes a history entry on open and closes itself on `popstate`
- Uses a ref to track whether we pushed an entry, rather than checking `event.state`
- On manual close (X button, Escape, overlay click), calls `history.back()` to clean up the extra entry

## Affected Components

- `Modal` — new `backCloses` prop
- `FileViewerModal` (FilePathLink) — file viewer in chat
- `BashRenderer` — command output
- `WriteRenderer` — file content
- `WriteStdinRenderer` — stdin content
- `EditRenderer` — diff / raw patch (7 instances)
- `GrepRenderer` — search results
- `ViewImageRenderer` — image viewer
- `FileViewer` — embedded project file viewer