### PR TITLE
Fix PWA install detection

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/icon-192.png" type="image/png" sizes="192x192" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <meta name="theme-color" content="#1a1a2e" />
     <style>
       /* Critical CSS to prevent flash of white background - only html, body/root handled by main CSS */

--- a/packages/client/remote.html
+++ b/packages/client/remote.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/icon-192.png" type="image/png" sizes="192x192" />
     <link rel="apple-touch-icon" href="/icon-192.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.json" crossorigin="use-credentials" />
     <meta name="theme-color" content="#1a1a2e" />
     <style>
       /* Critical CSS to prevent flash of white background - only html, body/root handled by main CSS */

--- a/packages/client/src/lib/registerServiceWorker.ts
+++ b/packages/client/src/lib/registerServiceWorker.ts
@@ -1,0 +1,53 @@
+/**
+ * Register Service Worker at startup to enable PWA capabilities (install, etc.)
+ * out of the box, without requiring the user to visit notification settings first.
+ *
+ * Decoupled from push subscription: SW registration is PWA infrastructure
+ * needed by all users; push subscription is opt-in.
+ */
+import { api } from "../api/client";
+
+/** Service Worker file path, compatible with Vite base URL (local "/" and remote "/remote/") */
+const SW_PATH = `${import.meta.env.BASE_URL}sw.js`;
+
+/** Whether the browser supports Service Worker */
+const hasBrowserSupport =
+  typeof window !== "undefined" &&
+  "serviceWorker" in navigator;
+
+/**
+ * Register Service Worker at application startup.
+ * Only registers the SW itself, does not subscribe to push notifications.
+ */
+export async function registerServiceWorkerAtStartup(): Promise<void> {
+  if (!hasBrowserSupport) return;
+
+  // In dev mode, check server setting (allows runtime toggle via settings UI)
+  if (import.meta.env.DEV) {
+    try {
+      const response = await api.getServerSettings();
+      if (!response.settings.serviceWorkerEnabled) {
+        console.log(
+          "[registerServiceWorker] Service worker disabled by server setting",
+        );
+        return;
+      }
+    } catch {
+      // If settings fetch fails, proceed with SW enabled (fail open)
+      console.warn(
+        "[registerServiceWorker] Failed to fetch server settings, proceeding with SW enabled",
+      );
+    }
+  }
+
+  try {
+    // Calling register() on an already-registered SW returns the existing registration
+    const reg = await navigator.serviceWorker.register(SW_PATH);
+    console.log(
+      "[registerServiceWorker] Service worker registered:",
+      reg.scope,
+    );
+  } catch (err) {
+    console.error("[registerServiceWorker] Failed to register:", err);
+  }
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -12,6 +12,7 @@ import { initializeContentMaxWidth } from "./hooks/useContentMaxWidth";
 import { initializeOutputAppearance } from "./hooks/useOutputAppearance";
 import { initializeTabSize } from "./hooks/useTabSize";
 import { initializeTheme } from "./hooks/useTheme";
+import { registerServiceWorkerAtStartup } from "./lib/registerServiceWorker";
 import { NavigationLayout } from "./layouts";
 import { ActivityPage } from "./pages/ActivityPage";
 import { AgentsPage } from "./pages/AgentsPage";
@@ -33,6 +34,9 @@ initializeFontSize();
 initializeOutputAppearance();
 initializeTabSize();
 initializeContentMaxWidth();
+
+// Register SW at startup so PWA install is available without visiting settings
+registerServiceWorkerAtStartup();
 
 // SSE activity stream connection is managed by useActivityBusConnection hook
 // in App.tsx, which connects only when authenticated (or auth is disabled)

--- a/packages/client/src/remote-main.tsx
+++ b/packages/client/src/remote-main.tsx
@@ -51,6 +51,7 @@ import { RelayLoginPage } from "./pages/RelayLoginPage";
 import { SessionPage } from "./pages/SessionPage";
 import { SettingsLayout } from "./pages/settings";
 import { useRemoteBasePath } from "./hooks/useRemoteBasePath";
+import { registerServiceWorkerAtStartup } from "./lib/registerServiceWorker";
 import "./styles/index.css";
 
 // Apply saved preferences before React renders to avoid flash
@@ -59,6 +60,9 @@ initializeFontSize();
 initializeOutputAppearance();
 initializeTabSize();
 initializeContentMaxWidth();
+
+// Register SW at startup so PWA install is available without visiting settings
+registerServiceWorkerAtStartup();
 
 // Get base URL for router (Vite sets this based on --base flag)
 // Remove trailing slash for BrowserRouter basename


### PR DESCRIPTION
This PR fixes two issues that prevented the browser from recognizing the app as installable (PWA):

### Problem 1: Service Worker only registered after visiting notification settings

Previously, the Service Worker was only registered inside the `usePushNotifications` hook, which runs when the user visits the notification settings page. If a user never visited that page, the SW was never registered, and the browser never offered the PWA install prompt — only a basic "Add shortcut" option.

### Problem 2: `manifest.json` blocked by Cloudflare Access

When the app is served behind Cloudflare Tunnel with an Access Application policy, Chrome requests `manifest.json` **without cookies** by default (anonymous request). Cloudflare Access sees an unauthenticated request and returns the OTP login page instead of the actual manifest, so the browser silently fails to detect the PWA.

### Fix

1. **Add `crossorigin="use-credentials"` to the manifest `<link>`** — This tells Chrome to send cookies when fetching `manifest.json`. Cloudflare Access sees the authenticated session cookie and passes the request through directly, no bypass rules needed.

2. **Register Service Worker at app startup** — A new `registerServiceWorkerAtStartup()` module is called in both `main.tsx` and `remote-main.tsx` before React renders. SW registration is now decoupled from push subscription: the SW is PWA infrastructure needed by all users, while push notifications remain opt-in.

### Changes

- `packages/client/index.html` — add `crossorigin="use-credentials"` to manifest link
- `packages/client/remote.html` — same
- `packages/client/src/lib/registerServiceWorker.ts` — new module, registers SW at startup
- `packages/client/src/main.tsx` — call `registerServiceWorkerAtStartup()` before render
- `packages/client/src/remote-main.tsx` — same