### PR TITLE
fix(voice): stop restart loop after recognition errors

### DIFF
--- a/packages/client/src/lib/__tests__/speechProviders.test.ts
+++ b/packages/client/src/lib/__tests__/speechProviders.test.ts
@@ -642,6 +642,25 @@ describe("browser-native speech provider", () => {
 
     provider.dispose();
   });
+
+  it("does not restart after a browser-native network error", () => {
+    const Recognition = installFakeSpeechRecognition();
+    const start = vi.spyOn(Recognition.prototype, "start");
+    const provider = new BrowserNativeProvider();
+
+    provider.start();
+    Recognition.instance?.onerror?.({ error: "network" } as unknown as Event);
+    Recognition.instance?.onend?.(new Event("end"));
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(provider.getState()).toMatchObject({
+      status: "error",
+      isListening: false,
+      error: "Network error - check connection",
+    });
+
+    provider.dispose();
+  });
 });
 
 describe("YA server speech provider", () => {

--- a/packages/client/src/lib/speechProviders/BrowserNativeProvider.ts
+++ b/packages/client/src/lib/speechProviders/BrowserNativeProvider.ts
@@ -102,6 +102,7 @@ export class BrowserNativeProvider implements SpeechProvider {
   private readonly subscribers = new Set<SpeechProviderSubscriber>();
   private recognition: SpeechRecognition | null = null;
   private isStopping = false;
+  private terminalError = false;
   private lastFinalTranscript = "";
   private disposed = false;
   private speechActivityTimer: ReturnType<typeof setTimeout> | null = null;
@@ -145,6 +146,7 @@ export class BrowserNativeProvider implements SpeechProvider {
     }
 
     this.isStopping = false;
+    this.terminalError = false;
     this.lastFinalTranscript = "";
     this.setState({
       status: "starting",
@@ -269,6 +271,7 @@ export class BrowserNativeProvider implements SpeechProvider {
           errorMessage = `Error: ${event.error}`;
       }
 
+      this.terminalError = true;
       this.setState({
         error: errorMessage,
         status: "error",
@@ -279,8 +282,14 @@ export class BrowserNativeProvider implements SpeechProvider {
 
     recognition.onend = () => {
       this.clearSpeechActivityTimer();
-      if (!this.isStopping && this.recognition === recognition) {
-        // Auto-restart after Chrome's ~60s idle timeout.
+      if (
+        !this.isStopping &&
+        !this.terminalError &&
+        this.recognition === recognition
+      ) {
+        // Auto-restart after Chrome's ~60s idle timeout, but never after a
+        // recognition error: retrying a failed speech service immediately can
+        // create a tight start/error/end loop.
         this.setState({ status: "reconnecting", error: null });
         try {
           recognition.start();
@@ -296,7 +305,7 @@ export class BrowserNativeProvider implements SpeechProvider {
         this.setState({
           isListening: false,
           interimTranscript: "",
-          status: "idle",
+          status: this.terminalError ? "error" : "idle",
         });
         this.options.onEnd?.();
       }


### PR DESCRIPTION
## Summary
- prevent BrowserNativeProvider from restarting recognition after terminal browser errors
- preserve the error state when the browser fires `onend` after an error
- add a regression test covering a `network` error followed by `onend`

## Test plan
- [x] `pnpm typecheck`
- [x] focused `speechProviders.test.ts` (56 tests)
- [x] Previously ran the full test suite and production bundle on the original release branch
- [x] Rebased onto current `main`, resolved the provider conflict, and reran typechecking plus focused tests