### PR TITLE
Resolve the OpenCode CLI from multi-line Windows PATH output

### DIFF
--- a/packages/server/src/sdk/providers/opencode-binary-selection.ts
+++ b/packages/server/src/sdk/providers/opencode-binary-selection.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import { win32 as windowsPath } from "node:path";
+
+/**
+ * Pick a usable OpenCode binary out of `which` / `where` output.
+ *
+ * Windows `where` prints one line per PATHEXT match, so the raw stdout routinely
+ * holds several paths and trimming it whole yields a string that is not a path at
+ * all. Split first, then prefer a directly executable file: `getAvailableModels()`
+ * runs the binary through `execFile()`, which on Windows cannot start npm's
+ * extensionless shell shim (ENOENT) or a `.cmd` shim (EINVAL) — only a real
+ * `.exe`. `opencode serve` is spawned with `shell: true` and does tolerate the
+ * shims, so a shim is still returned as a last resort rather than reporting that
+ * OpenCode is missing entirely.
+ */
+export function selectOpenCodeBinary(
+  stdout: string,
+  platform: NodeJS.Platform = process.platform,
+  fileExists: (path: string) => boolean = existsSync,
+): string | null {
+  const hits = stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => fileExists(line));
+
+  if (platform !== "win32") {
+    return hits[0] ?? null;
+  }
+
+  const directExe = hits.find((hit) => hit.toLowerCase().endsWith(".exe"));
+  if (directExe) {
+    return directExe;
+  }
+
+  // `npm i -g opencode-ai` drops `opencode` and `opencode.cmd` shims beside the
+  // global node_modules; the executable itself is opencode-ai/bin/opencode.exe.
+  // Resolve with the win32 path rules explicitly so the lookup behaves the same
+  // when these strings are exercised from a posix test host.
+  for (const hit of hits) {
+    const packaged = windowsPath.join(
+      hit,
+      "..",
+      "node_modules",
+      "opencode-ai",
+      "bin",
+      "opencode.exe",
+    );
+    if (fileExists(packaged)) {
+      return packaged;
+    }
+  }
+
+  return hits[0] ?? null;
+}

--- a/packages/server/src/sdk/providers/opencode.ts
+++ b/packages/server/src/sdk/providers/opencode.ts
@@ -34,6 +34,7 @@ import { parseOpenCodeSSEEvent } from "@yep-anywhere/shared";
 import { getLogger } from "../../logging/logger.js";
 import { whichCommand } from "../cli-detection.js";
 import { MessageQueue } from "../messageQueue.js";
+import { selectOpenCodeBinary } from "./opencode-binary-selection.js";
 import {
   mapOpenCodeQuestionAnswers,
   normalizeOpenCodeTool,
@@ -1670,9 +1671,9 @@ export class OpenCodeProvider implements AgentProvider {
       const { stdout } = await execAsync(whichCommand("opencode"), {
         encoding: "utf-8",
       });
-      const result = stdout.trim();
-      if (result && existsSync(result)) {
-        return result;
+      const resolved = selectOpenCodeBinary(stdout);
+      if (resolved) {
+        return resolved;
       }
     } catch {
       // Not in PATH

--- a/packages/server/test/sdk/providers/opencode-binary-selection.test.ts
+++ b/packages/server/test/sdk/providers/opencode-binary-selection.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for selectOpenCodeBinary().
+ *
+ * Regression cover for OpenCode being undetectable on Windows: `where` prints one
+ * line per PATHEXT match, so trimming the whole stdout produced a multi-line string
+ * that existsSync() always rejected and findOpenCodePath() returned null. Sessions
+ * still showed up (the reader parses OpenCode's storage directly and needs no
+ * binary), but none of them could be started.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { selectOpenCodeBinary } from "../../../src/sdk/providers/opencode-binary-selection.js";
+
+// Verbatim `where opencode` output on Windows with opencode installed via npm.
+const WINDOWS_WHERE_OUTPUT =
+  "C:\\nvm4w\\nodejs\\opencode\r\nC:\\nvm4w\\nodejs\\opencode.cmd\r\n";
+
+const NPM_SHIM = "C:\\nvm4w\\nodejs\\opencode";
+const NPM_CMD_SHIM = "C:\\nvm4w\\nodejs\\opencode.cmd";
+const PACKAGED_EXE =
+  "C:\\nvm4w\\nodejs\\node_modules\\opencode-ai\\bin\\opencode.exe";
+
+/** Model a filesystem where only the listed paths exist. */
+function fakeFs(...existing: string[]) {
+  const present = new Set(existing);
+  return (path: string) => present.has(path);
+}
+
+describe("selectOpenCodeBinary", () => {
+  it("resolves the packaged .exe from multi-line Windows `where` output", () => {
+    const selected = selectOpenCodeBinary(
+      WINDOWS_WHERE_OUTPUT,
+      "win32",
+      fakeFs(NPM_SHIM, NPM_CMD_SHIM, PACKAGED_EXE),
+    );
+
+    expect(selected).toBe(PACKAGED_EXE);
+  });
+
+  it("prefers a .exe that `where` reported directly", () => {
+    const standaloneExe = "C:\\Users\\me\\.opencode\\bin\\opencode.exe";
+
+    const selected = selectOpenCodeBinary(
+      `${NPM_SHIM}\r\n${standaloneExe}\r\n`,
+      "win32",
+      fakeFs(NPM_SHIM, standaloneExe),
+    );
+
+    expect(selected).toBe(standaloneExe);
+  });
+
+  it("falls back to the first PATH hit when no .exe can be resolved", () => {
+    // A shim `spawn(..., { shell: true })` can still run, so `opencode serve`
+    // works even though `execFile`-based model discovery will not.
+    const selected = selectOpenCodeBinary(
+      WINDOWS_WHERE_OUTPUT,
+      "win32",
+      fakeFs(NPM_SHIM, NPM_CMD_SHIM),
+    );
+
+    expect(selected).toBe(NPM_SHIM);
+  });
+
+  it("returns null when nothing reported on PATH exists", () => {
+    const selected = selectOpenCodeBinary(
+      WINDOWS_WHERE_OUTPUT,
+      "win32",
+      fakeFs(),
+    );
+
+    expect(selected).toBeNull();
+  });
+
+  it("returns null for empty `where` output", () => {
+    expect(selectOpenCodeBinary("\r\n", "win32", fakeFs())).toBeNull();
+  });
+
+  it("returns the single `which` hit on posix", () => {
+    const selected = selectOpenCodeBinary(
+      "/usr/local/bin/opencode\n",
+      "linux",
+      fakeFs("/usr/local/bin/opencode"),
+    );
+
+    expect(selected).toBe("/usr/local/bin/opencode");
+  });
+
+  it("takes the first existing hit from multi-line `which -a` output on posix", () => {
+    const selected = selectOpenCodeBinary(
+      "/opt/homebrew/bin/opencode\n/usr/local/bin/opencode\n",
+      "darwin",
+      fakeFs("/opt/homebrew/bin/opencode", "/usr/local/bin/opencode"),
+    );
+
+    expect(selected).toBe("/opt/homebrew/bin/opencode");
+  });
+
+  it("skips reported paths that no longer exist", () => {
+    const selected = selectOpenCodeBinary(
+      "/stale/bin/opencode\n/usr/local/bin/opencode\n",
+      "linux",
+      fakeFs("/usr/local/bin/opencode"),
+    );
+
+    expect(selected).toBe("/usr/local/bin/opencode");
+  });
+});


### PR DESCRIPTION
## Summary

On Windows, OpenCode sessions are listed but none of them can be started — `startSession()` reports "OpenCode CLI not found" even with `opencode` on PATH.

`findOpenCodePath()` locates the binary with `whichCommand("opencode")`, which is `where` on Windows. Unix `which` prints a single line, but `where` prints one line per PATHEXT match, so a machine with opencode installed from npm gets back both `C:\...\opencode` and `C:\...\opencode.cmd`. The following `stdout.trim()` only strips the outer whitespace, so the newline between them survives and `existsSync()` is handed a two-line string that can never exist. Detection returns null, and `isInstalled()`, `getAuthStatus()`, `getAvailableModels()` and `startSession()` all fail with it. Sessions still appear because `OpenCodeSessionReader` reads OpenCode's storage directly and never needs the binary, which is what makes this look like a UI problem rather than a detection one.

The fix splits the lookup output into lines before testing them. Taking the first surviving line isn't quite enough on Windows, because the provider invokes the binary two different ways: `opencode serve` goes through `spawn(..., { shell: true })` and is happy with npm's shims, but `getAvailableModels()` uses `execFile()` with no shell, which cannot start `opencode.cmd` (EINVAL since the CVE-2024-27980 hardening) or npm's extensionless bash shim (ENOENT). Checked here against opencode-ai 1.18.16 on Node 24, only `node_modules/opencode-ai/bin/opencode.exe` works under both. So on Windows the selection prefers a real `.exe`, then tries resolving a shim to its packaged `.exe`, and only then falls back to the first raw hit — a shim still lets `opencode serve` run even though model discovery stays empty, which seemed better than reporting OpenCode as missing outright. Happy to drop that last fallback and return null instead if you would rather it fail loudly.

I pulled the choice out into `selectOpenCodeBinary()`, taking the platform and an existence probe as parameters the way `getDefaultAllowedImagePaths()` and `detectDesktopProviderApplication()` do, so the Windows paths are covered from a posix CI without mocking. It resolves the shim with `path.win32` explicitly, since `path.join` on Linux would not treat `\` as a separator and the lookup would quietly fail there.

## Validation

`pnpm --filter @yep-anywhere/server test -- test/sdk/providers/opencode-binary-selection.test.ts` — 8 new tests pass, covering win32, linux and darwin without gating on the host platform.

`pnpm --filter @yep-anywhere/server exec tsc --noEmit` is clean, and `biome lint` and `biome format` report nothing on the three touched files.

Full `pnpm --filter @yep-anywhere/server test` on this Windows host gives 208 failed / 3752 passed; clean HEAD on the same machine gives 208 failed / 3744 passed. So this adds its 8 tests and moves nothing else. Those 208 look pre-existing on Windows — EBUSY unlinking temp `opencode.db` files, and Codex tests expecting a CLI that isn't installed here — and I have not investigated them.

End to end on the affected machine (Windows 11, opencode-ai 1.18.16 installed globally through npm): before the change `findOpenCodePath()` returned null, `isInstalled()` was false and `getAvailableModels()` returned nothing. After it, the path resolves to `opencode-ai\bin\opencode.exe`, `isInstalled()` is true, and model discovery returns 20 models.

On the AGENTS.md rule for OS-sensitive changes: the runtime verification above is Windows-only. The posix branch is covered by the unit tests but I have not exercised it against a real `which` on Linux or macOS.

## Client/server compatibility

Not applicable. This is server-side CLI discovery with no new or changed route, response field, event, or protocol semantic.
