### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ Read more: [How we use the SDK](https://yepanywhere.com/tos-compliance.html) | [
 
 ## Star History
 
-<a href="https://www.star-history.com/#kzahel/yepanywhere&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#kzahel/yepanywhere&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kzahel/yepanywhere&type=date&legend=top-left&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kzahel/yepanywhere&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kzahel/yepanywhere&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=kzahel/yepanywhere&type=date&legend=top-left&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=kzahel/yepanywhere&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=kzahel/yepanywhere&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README has been broken and no longer renders. This updates the chart links to a working source so the stargazer history displays correctly again, while keeping the dark theme and the existing chart options.

Both the wrapping link and the chart images are updated to star-history.dera.page.